### PR TITLE
Stop indexing lines

### DIFF
--- a/src/gudrun_classes/gud_file.py
+++ b/src/gudrun_classes/gud_file.py
@@ -1,5 +1,6 @@
 import os
 from os.path import isfile
+from src.gudrun_classes.exception import ParserException
 
 
 class GudFile:
@@ -111,10 +112,10 @@ class GudFile:
 
         # Handle edge cases - invalid extensions and paths.
         if self.path.split(".")[-1] != "gud":
-            raise ValueError("Only .gud files can be parsed.")
+            raise ParserException("Only .gud files can be parsed.")
 
         if not isfile(self.path):
-            raise ValueError("Please provide a valid path.")
+            raise ParserException("Please provide a valid path.")
 
         # Parse the GudFile
         self.parse()

--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -221,14 +221,13 @@ class GudrunFile:
         """
         Intialises an Instrument object and assigns it to the
         instrument attribute.
-        Parses the attributes of the Instrument from the input lines.
+        Parses the attributes of the Instrument from the input stream.
         Raises a ValueError if any mandatory attributes are missing.
 
 
         Parameters
         ----------
-        lines : str
-            Input lines to parse the Instrument from.
+        None
         Returns
         -------
         None
@@ -400,14 +399,13 @@ class GudrunFile:
         """
         Intialises a Beam object and assigns it to the
         beam attribute.
-        Parses the attributes of the Beam from the input lines.
+        Parses the attributes of the Beam from the input stream.
         Raises a ValueError if any mandatory attributes are missing.
 
 
         Parameters
         ----------
-        lines : str
-            Input lines to parse the Beam from.
+        None
         Returns
         -------
         None
@@ -495,14 +493,13 @@ class GudrunFile:
         """
         Intialises a Normalisation object and assigns it to the
         normalisation attribute.
-        Parses the attributes of the Normalisation from the input lines.
+        Parses the attributes of the Normalisation from the input stream.
         Raises a ValueError if any mandatory attributes are missing.
 
 
         Parameters
         ----------
-        lines : str
-            Input lines to parse the Normalisation from.
+        None
         Returns
         -------
         None
@@ -667,14 +664,13 @@ class GudrunFile:
     def parseSampleBackground(self):
         """
         Intialises a SampleBackground object.
-        Parses the attributes of the SampleBackground from the input lines.
+        Parses the attributes of the SampleBackground from the input stream.
         Raises a ValueError if any mandatory attributes are missing.
         Returns the parsed object.
 
         Parameters
         ----------
-        lines : str
-            Input lines to parse the Instrument from.
+        None
         Returns
         -------
         sampleBackground : SampleBackground
@@ -709,14 +705,13 @@ class GudrunFile:
     def parseSample(self):
         """
         Intialises a Sample object.
-        Parses the attributes of the Sample from the input lines.
+        Parses the attributes of the Sample from the input stream.
         Raises a ValueError if any mandatory attributes are missing.
         Returns the parsed object.
 
         Parameters
         ----------
-        lines : str
-            Input lines to parse the Instrument from.
+        None
         Returns
         -------
         sample : Sample
@@ -889,14 +884,13 @@ class GudrunFile:
     def parseContainer(self):
         """
         Intialises a Container object.
-        Parses the attributes of the Container from the input lines.
+        Parses the attributes of the Container from the input stream.
         Raises a ValueError if any mandatory attributes are missing.
         Returns the parsed object.
 
         Parameters
         ----------
-        lines : str
-            Input lines to parse the Instrument from.
+        None
         Returns
         -------
         container : Container
@@ -1017,15 +1011,12 @@ class GudrunFile:
     def makeParse(self, key):
         """
         Calls a parsing function from a dictionary of parsing functions
-        by the input key. The input lines are passed as an argument.
+        by the input key.
         Returns the result of the called parsing function.
         Only use case is as a helper function during parsing.
 
         Parameters
         ----------
-        lines : list
-            List of strings. Each element of the list is a line from the
-            input file.
         key : str
             Parsing function to call
             (INSTRUMENT/BEAM/NORMALISATION/SAMPLE BACKGROUND/SAMPLE/CONTAINER)

--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -222,7 +222,7 @@ class GudrunFile:
         Intialises an Instrument object and assigns it to the
         instrument attribute.
         Parses the attributes of the Instrument from the input stream.
-        Raises a ValueError if any mandatory attributes are missing.
+        Raises a ParserException if any mandatory attributes are missing.
 
 
         Parameters
@@ -400,7 +400,7 @@ class GudrunFile:
         Intialises a Beam object and assigns it to the
         beam attribute.
         Parses the attributes of the Beam from the input stream.
-        Raises a ValueError if any mandatory attributes are missing.
+        Raises a ParserException if any mandatory attributes are missing.
 
 
         Parameters
@@ -494,7 +494,7 @@ class GudrunFile:
         Intialises a Normalisation object and assigns it to the
         normalisation attribute.
         Parses the attributes of the Normalisation from the input stream.
-        Raises a ValueError if any mandatory attributes are missing.
+        Raises a ParserException if any mandatory attributes are missing.
 
 
         Parameters
@@ -665,7 +665,7 @@ class GudrunFile:
         """
         Intialises a SampleBackground object.
         Parses the attributes of the SampleBackground from the input stream.
-        Raises a ValueError if any mandatory attributes are missing.
+        Raises a ParserException if any mandatory attributes are missing.
         Returns the parsed object.
 
         Parameters
@@ -706,7 +706,7 @@ class GudrunFile:
         """
         Intialises a Sample object.
         Parses the attributes of the Sample from the input stream.
-        Raises a ValueError if any mandatory attributes are missing.
+        Raises a ParserException if any mandatory attributes are missing.
         Returns the parsed object.
 
         Parameters
@@ -885,7 +885,7 @@ class GudrunFile:
         """
         Intialises a Container object.
         Parses the attributes of the Container from the input stream.
-        Raises a ValueError if any mandatory attributes are missing.
+        Raises a ParserException if any mandatory attributes are missing.
         Returns the parsed object.
 
         Parameters
@@ -1050,9 +1050,7 @@ class GudrunFile:
         Returns the SampleBackground object.
         Parameters
         ----------
-        lines : list
-            List of strings. Each element of the list is a line from the
-            input file.
+        None
         Returns
         -------
         SampleBackground
@@ -1087,7 +1085,8 @@ class GudrunFile:
         """
         Parse the GudrunFile from its path.
         Assign objects from the file to the attributes of the class.
-        Raises ValueError if Instrument, Beam or Normalisation are missing.
+        Raises ParserException if Instrument,
+        Beam or Normalisation are missing.
 
         Parameters
         ----------
@@ -1099,11 +1098,11 @@ class GudrunFile:
 
         # Ensure only valid files are given.
         if not self.path:
-            raise ValueError(
+            raise ParserException(
                 "Path not supplied. Cannot parse from an empty path!"
             )
         if not isfile(self.path):
-            raise ValueError(
+            raise ParserException(
                 "The path supplied is invalid.\
                  Cannot parse from an invalid path"
             )
@@ -1132,7 +1131,7 @@ class GudrunFile:
 
         # If we didn't parse each one of the keywords, then panic.
         if not all(KEYWORDS.values()):
-            raise ValueError((
+            raise ParserException((
                 'INSTRUMENT, BEAM and NORMALISATION'
                 ' were not parsed. It\'s possible the file'
                 ' supplied is of an incorrect format!'

--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -54,36 +54,52 @@ class GudrunFile:
         Normalisation object extracted from the input file.
     sampleBackgrounds : SampleBackground[]
         List of SampleBackgrounds extracted from the input file.
+    stream : str[]
+        List of strings, where each item represents a line
+        in the input stream.
     Methods
     -------
-    parseInstrument(lines):
+    getNextToken():
+        Returns the next token in the input stream, whilst
+        removing it from said input stream.
+    peekNextToken():
+        Returns the next token in the input stream without
+        removing it.
+    consumeTokens(n):
+        Removes n tokens from the input stream.
+    consumeUpToDelim(delim):
+        Removes tokens until the delimiter is reached.
+    consumeWhitespace():
+        Removes tokens from the stream, until a non-whitespace
+        token is reached.
+    parseInstrument():
         Initialises an Intrument object and assigns it
         to the instrument attribute.
-        Parses the attributes of the Instrument from the input lines.
-    parseBeam(lines):
+        Parses the attributes of the Instrument from the input stream.
+    parseBeam():
         Initialises a Beam object and assigns it to the beam attribute.
-        Parses the attributes of the Beam from the input lines.
-    parseNormalisation(lines):
+        Parses the attributes of the Beam from the input stream.
+    parseNormalisation():
         Initialises a Normalisation object and assigns it
         to the normalisation attribute.
-        Parses the attributes of the Normalisation from the input lines.
-    parseSampleBackground(lines):
+        Parses the attributes of the Normalisation from the input stream.
+    parseSampleBackground():
         Initialises a SampleBackground object.
-        Parses the attributes of the SampleBackground from the input lines.
+        Parses the attributes of the SampleBackground from the input stream.
         Returns the SampleBackground object.
-    parseSample(lines):
+    parseSample():
         Initialises a Sample object.
-        Parses the attributes of the Sample from the input lines.
+        Parses the attributes of the Sample from the input stream.
         Returns the Sample object.
-    parseContainer(lines):
+    parseContainer():
         Initialises a Container object.
-        Parses the attributes of the Container from the input lines.
+        Parses the attributes of the Container from the input stream.
         Returns the Container object.
-    makeParse(lines, key):
+    makeParse(key):
         Uses the key to call a parsing function from a dictionary
-        of parsing functions. The lines are passed as an argument.
+        of parsing functions.
         Returns the result of the called parsing function.
-    sampleBackgroundHelper(lines):
+    sampleBackgroundHelper():
         Parses the SampleBackground, its Samples and their Containers.
         Returns the SampleBackground object.
     parse():
@@ -130,21 +146,72 @@ class GudrunFile:
         self.parse()
 
     def getNextToken(self):
-        return self.stream.pop(0)
+        """
+        Pops the 'next token' from the stream and returns it.
+        Essentially removes the first line in the stream and returns it.
+
+        Parameters
+        ----------
+        None
+        Returns
+        -------
+        str | None
+        """
+        return self.stream.pop(0) if self.stream else None
 
     def peekNextToken(self):
+        """
+        Returns the next token in the input stream, without removing it.
+
+        Parameters
+        ----------
+        None
+        Returns
+        -------
+        str | None
+        """
         return self.stream[0] if self.stream else None
 
     def consumeTokens(self, n):
+        """
+        Consume n tokens from the input stream.
+
+        Parameters
+        ----------
+        None
+        Returns
+        -------
+        None
+        """
         for _ in range(n):
             self.getNextToken()
 
     def consumeUpToDelim(self, delim):
+        """
+        Consume tokens iteratively, until a delimiter is reached.
+
+        Parameters
+        ----------
+        None
+        Returns
+        -------
+        None
+        """
         line = self.getNextToken()
         while line[0] != delim:
             line = self.getNextToken()
 
     def consumeWhitespace(self):
+        """
+        Consume tokens iteratively, while they are whitespace.
+
+        Parameters
+        ----------
+        None
+        Returns
+        -------
+        None
+        """
         line = self.peekNextToken()
         if line.isspace():
             self.getNextToken()

--- a/tests/test_gud_file.py
+++ b/tests/test_gud_file.py
@@ -1,4 +1,5 @@
 import os
+from src.gudrun_classes.exception import ParserException
 from unittest import TestCase
 from shutil import copyfile
 
@@ -10,7 +11,6 @@ from src.scripts.utils import extract_floats_from_string
 class TestParseGudFile(TestCase):
 
     def setUp(self) -> None:
-
         self.expectedGudFileA = {
             "path": "NIMROD00016608_H2O_in_N9.gud",
             "name": "NIMROD00016608_H2O_in_N9.gud",
@@ -259,17 +259,17 @@ class TestParseGudFile(TestCase):
     def testEmptyPath(self):
 
         emptyPath = ""
-        self.assertRaises(ValueError, GudFile, emptyPath)
+        self.assertRaises(ParserException, GudFile, emptyPath)
 
     def testInvalidFileType(self):
 
         invalid_file_type = "NIMROD0001_H20_in_N9.txt"
-        self.assertRaises(ValueError, GudFile, invalid_file_type)
+        self.assertRaises(ParserException, GudFile, invalid_file_type)
 
     def testInvalidPath(self):
 
         invalid_path = "invalid_path.gud"
-        self.assertRaises(ValueError, GudFile, invalid_path)
+        self.assertRaises(ParserException, GudFile, invalid_path)
 
     def testValidPath(self):
         g = GudrunFile("tests/TestData/NIMROD-water/good_water.txt")

--- a/tests/test_gudpy_io.py
+++ b/tests/test_gudpy_io.py
@@ -1212,6 +1212,7 @@ class TestGudPyIO(TestCase):
         expectedContainerA.pop("outerRadius", None)
         expectedContainerA.pop("sampleHeight", None)
         expectedContainerA.pop("geometry", None)
+        expectedContainerA.pop("attenuationCoefficient")
         self.goodSampleBackground.samples[0].containers[0].dataFiles = (
             DataFiles([], "")
         )
@@ -1241,6 +1242,8 @@ class TestGudPyIO(TestCase):
                     + "\n\n}"
                 )
                 f.write("\n\n{}\n\nEND".format(str(badSampleBackground)))
+            with open("test_data.txt", "r") as f:
+                print(f.read())
             with self.assertRaises(ParserException) as cm:
                 GudrunFile("test_data.txt")
                 self.assertEqual(
@@ -1261,6 +1264,7 @@ class TestGudPyIO(TestCase):
         expectedContainerA.pop("outerRadius", None)
         expectedContainerA.pop("sampleHeight", None)
         expectedContainerA.pop("geometry", None)
+        expectedContainerA.pop("attenuationCoefficient")
         self.goodSampleBackground.samples[0].containers[0].dataFiles = (
             DataFiles([], "")
         )

--- a/tests/test_gudpy_io.py
+++ b/tests/test_gudpy_io.py
@@ -718,7 +718,7 @@ class TestGudPyIO(TestCase):
     def testLoadEmptyGudrunFile(self):
         f = open("test_data.txt", "w", encoding="utf-8")
         f.close()
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ParserException) as cm:
             GudrunFile("test_data.txt")
         self.assertEqual((
                     'INSTRUMENT, BEAM and NORMALISATION'
@@ -738,7 +738,7 @@ class TestGudPyIO(TestCase):
                 + "\n\n}\n\n"
             )
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ParserException) as cm:
             GudrunFile("test_data.txt")
         self.assertEqual((
                     'INSTRUMENT, BEAM and NORMALISATION'
@@ -760,7 +760,7 @@ class TestGudPyIO(TestCase):
                 + str(self.goodNormalisation)
                 + "\n\n}"
             )
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ParserException) as cm:
             GudrunFile("test_data.txt")
         self.assertEqual((
                     'INSTRUMENT, BEAM and NORMALISATION'
@@ -779,7 +779,7 @@ class TestGudPyIO(TestCase):
             )
             f.write("BEAM        {\n\n" + str(self.goodBeam) + "\n\n}\n\n")
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ParserException) as cm:
             GudrunFile("test_data.txt")
         self.assertEqual((
                     'INSTRUMENT, BEAM and NORMALISATION'
@@ -798,7 +798,7 @@ class TestGudPyIO(TestCase):
                 + "\n\n}"
             )
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ParserException) as cm:
             GudrunFile("test_data.txt")
         self.assertEqual((
             'INSTRUMENT, BEAM and NORMALISATION'
@@ -812,7 +812,7 @@ class TestGudPyIO(TestCase):
             f.write("'  '  '        '  '/'\n\n")
             f.write("BEAM        {\n\n" + str(self.goodBeam) + "\n\n}")
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ParserException) as cm:
             GudrunFile("test_data.txt")
         self.assertEqual((
                     'INSTRUMENT, BEAM and NORMALISATION'
@@ -829,7 +829,7 @@ class TestGudPyIO(TestCase):
                 "INSTRUMENT        {\n\n" + str(self.goodInstrument) + "\n\n}"
             )
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(ParserException) as cm:
             GudrunFile("test_data.txt")
         self.assertEqual((
                     'INSTRUMENT, BEAM and NORMALISATION'

--- a/tests/test_gudrun_classes.py
+++ b/tests/test_gudrun_classes.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 
+from src.gudrun_classes.exception import ParserException
 from src.gudrun_classes.gudrun_file import GudrunFile
 from src.gudrun_classes.beam import Beam
 from src.gudrun_classes.composition import Composition
@@ -21,12 +22,12 @@ class TestGudrunClasses(TestCase):
     def testEmptyPath(self):
 
         emptyPath = ""
-        self.assertRaises(ValueError, GudrunFile, path=emptyPath)
+        self.assertRaises(ParserException, GudrunFile, path=emptyPath)
 
     def testInvalidPath(self):
 
         invalidPath = "invalid_path"
-        self.assertRaises(ValueError, GudrunFile, path=invalidPath)
+        self.assertRaises(ParserException, GudrunFile, path=invalidPath)
 
     def testInstrumentInitDataTypes(self):
 


### PR DESCRIPTION
Instead of indexing lines as such: `instrument.name = firstword(lines[0])`, a stream based approach has been implemented.
The `GudrunFile` class now supports the following methods:

- `getNextToken`
- `peekNextToken`
- `consumeTokens`
- `consumeWhitespace`
- `consumeUpToDelim`

Which are used to maintain a stream within the `GudrunFile` (which is now stored in an attribute, `stream`).

So now, getting the instrument name may look as such: `instrument.name = self.getNextToken()`.

Clearly this is better practice, but also makes the code easier to read - and we no longer have to worry about applying offsets to the indexes after parsing attributes which are of dynamic lengths (`DataFiles`, `Composition`, `groupingParameterPanel` etc.).

This PR closes #70.
