### PR TITLE
Manage GudPyTreeView using MV architecture solely

### DIFF
--- a/src/gudrun_classes/config.py
+++ b/src/gudrun_classes/config.py
@@ -1,3 +1,3 @@
 from src.gudrun_classes.enums import Geometry
-
 geometry = Geometry.FLATPLATE
+NUM_GUDPY_CORE_OBJECTS = 3

--- a/src/gui/widgets/gudpy_tree.py
+++ b/src/gui/widgets/gudpy_tree.py
@@ -216,7 +216,7 @@ class GudPyTreeModel(QAbstractItemModel):
                     0: "Instrument", 1: "Beam",
                     2: "Normalisation", 3: "Sample Background"
                 }
-                return QVariant(dic[index.row()])
+                return QVariant(dic[index.row() if index.row() <= 3 else 3])
             elif isinstance(index.internalPointer(), (Sample, Container)):
                 return QVariant(index.internalPointer().name)
         elif role == Qt.CheckStateRole and self.isSample(index):

--- a/src/gui/widgets/gudpy_tree.py
+++ b/src/gui/widgets/gudpy_tree.py
@@ -12,6 +12,7 @@ from src.gudrun_classes.normalisation import Normalisation
 from src.gudrun_classes.sample import Sample
 from src.gudrun_classes.sample_background import SampleBackground
 from src.gudrun_classes.container import Container
+from src.gudrun_classes.config import NUM_GUDPY_CORE_OBJECTS
 
 
 class GudPyTreeModel(QAbstractItemModel):
@@ -104,20 +105,25 @@ class GudPyTreeModel(QAbstractItemModel):
             if row in rows.keys():
                 obj = rows[row]
             else:
-                obj = self.gudrunFile.sampleBackgrounds[row-3]
+                obj = self.gudrunFile.sampleBackgrounds[
+                    row-NUM_GUDPY_CORE_OBJECTS
+                ]
         elif parent.isValid() and not parent.parent().isValid():
             # Valid parent and invalid grandparent, means that the index
             # corresponds to a sample.
             obj = (
-                self.gudrunFile.sampleBackgrounds[parent.row()-3]
+                self.gudrunFile.sampleBackgrounds[
+                    parent.row()-NUM_GUDPY_CORE_OBJECTS
+                ]
                 .samples[row]
             )
         elif parent.isValid() and parent.parent().isValid():
             # Valid parent and grandparent means that the index
             # corresponds to a container.
             obj = (
-                self.gudrunFile.sampleBackgrounds[parent.parent().row()-3]
-                .samples[parent.row()].containers[row]
+                self.gudrunFile.sampleBackgrounds[
+                    parent.parent().row()-NUM_GUDPY_CORE_OBJECTS
+                ].samples[parent.row()].containers[row]
             )
         else:
             # Otherwise we return an invalid index.
@@ -216,7 +222,12 @@ class GudPyTreeModel(QAbstractItemModel):
                     0: "Instrument", 1: "Beam",
                     2: "Normalisation", 3: "Sample Background"
                 }
-                return QVariant(dic[index.row() if index.row() <= 3 else 3])
+                return QVariant(
+                    dic[
+                        index.row() if index.row() <= NUM_GUDPY_CORE_OBJECTS
+                        else NUM_GUDPY_CORE_OBJECTS
+                    ]
+                )
             elif isinstance(index.internalPointer(), (Sample, Container)):
                 return QVariant(index.internalPointer().name)
         elif role == Qt.CheckStateRole and self.isSample(index):
@@ -282,13 +293,18 @@ class GudPyTreeModel(QAbstractItemModel):
         # If the parent is invalid, then it is a top level node.
         if not parent.isValid():
             # Instrument + Beam + Normalisation + N SampleBackgrounds
-            return 3 + len(self.gudrunFile.sampleBackgrounds)
+            return (
+                NUM_GUDPY_CORE_OBJECTS
+                + len(self.gudrunFile.sampleBackgrounds)
+            )
         elif parent.isValid() and not parent.parent().isValid():
             # If the parent is valid, but the grandparent is invalid
             # Return the number of samples of the sample background.
-            if parent.row() >= 3:
+            if parent.row() >= NUM_GUDPY_CORE_OBJECTS:
                 return len(
-                    self.gudrunFile.sampleBackgrounds[parent.row()-3].samples
+                    self.gudrunFile.sampleBackgrounds[
+                        parent.row()-NUM_GUDPY_CORE_OBJECTS
+                    ].samples
                 )
             else:
                 return 0
@@ -299,10 +315,11 @@ class GudPyTreeModel(QAbstractItemModel):
         ):
             # If it is a leaf, then return the number of
             # containers for the sample.
-            if parent.parent().row() >= 3:
+            if parent.parent().row() >= NUM_GUDPY_CORE_OBJECTS:
                 return len(
-                    self.gudrunFile.sampleBackgrounds[parent.parent().row()-3]
-                    .samples[parent.row()].containers
+                    self.gudrunFile.sampleBackgrounds[
+                        parent.parent().row()-NUM_GUDPY_CORE_OBJECTS
+                    ].samples[parent.row()].containers
                 )
             else:
                 return 0

--- a/src/gui/widgets/gudpy_tree.py
+++ b/src/gui/widgets/gudpy_tree.py
@@ -27,16 +27,11 @@ class GudPyTreeModel(QAbstractItemModel):
     ----------
     gudrunFile : GudrunFile
         GudrunFile object associated with the model.
-    _data : list
-        Data for the model to use.
-    checkStates : dict
-        Dictionary to manage check states.
-    root : GudPyNode
-        Root node of the tree.
+    persistentIndexes : dict
+        Dict of QPersistentIndexes,
+        key is a GudPy object, value is a QPersistentIndex.
     Methods
     -------
-    makeModel(root, data)
-        Creates the internal tree data structure.
     rowCount(parent)
         Returns the row count of an index.
     columnCount(parent)
@@ -45,21 +40,19 @@ class GudPyTreeModel(QAbstractItemModel):
         Returns the check state of a given index.
     data(index, role)
         Returns the data at a given index.
-    objectData(index)
-        Returns the object associated with a given index.
-    headerData(column, orientation, role)
-        Stub method.
     index(row, column, parent)
         Returns index associated with given row, column and parent.
     parent(index)
         Returns parent of a given index.
+    findParent(item)
+        Finds the parent of a given Sample or Container.
     flags(index)
         Returns flags associated with a given index.
     setData(index, value, role)
         Sets data at a given index.
     isSample(index)
         Returns whether a given index is associated with a sample.
-    included(index)
+    isIncluded(index)
         Returns whether a given index of a sample is to be ran.
     """
 
@@ -80,24 +73,52 @@ class GudPyTreeModel(QAbstractItemModel):
         self.persistentIndexes = {}
 
     def index(self, row, column, parent=QModelIndex()):
+        """
+        Returns index associated with given row, column and parent.
+        If no such index is possible, then an invalid QModelIndex
+        is returned.
+        Creates a QPersistentModelIndex and adds it to the dict,
+        to keep the internal pointer of the QModelIndex in
+        reference.
+        Parameters
+        ----------
+        row : int
+            Row number.
+        column : int
+            Column number.
+        parent, optional: QModelIndex
+            Parent index.
+        Returns
+        -------
+        QModelIndex
+            The index created.
+        """
+        # Check for invalid index.
         if not self.hasIndex(row, column, parent):
             return QModelIndex()
         elif not parent.isValid():
-            if row == 0:
-                obj = self.gudrunFile.instrument
-            elif row == 1:
-                obj = self.gudrunFile.beam
-            elif row == 2:
-                obj = self.gudrunFile.normalisation
+            # Invalid parent means we are at the top level.
+            rows = {0: self.gudrunFile.instrument, 1: self.gudrunFile.beam, 2: self.gudrunFile.normalisation}
+            # Instrument | Beam | Normalisation
+            if row in rows.keys():
+                obj = rows[row]
             else:
                 obj = self.gudrunFile.sampleBackgrounds[row-3]
         elif parent.isValid() and not parent.parent().isValid():
+            # Valid parent and invalid grandparent, means that the index
+            # corresponds to a sample.
             obj = self.gudrunFile.sampleBackgrounds[parent.row()-3].samples[row]
         elif parent.isValid() and parent.parent().isValid():
+            # Valid parent and grandparent means that the index
+            # corresponds to a container.
             obj = self.gudrunFile.sampleBackgrounds[parent.parent().row()-3].samples[parent.row()].containers[row]
         else:
+            # Otherwise we return an invalid index.
             return QModelIndex()
+        # Check that we don't already have the index in reference.
         if not obj in self.persistentIndexes.keys():
+            # Create the index and add a QPersistentModelIndex
+            # constructed from the index, to the dict.
             index = self.createIndex(row, 0, obj)
             self.persistentIndexes[obj] = QPersistentModelIndex(index)
             return index
@@ -105,6 +126,20 @@ class GudPyTreeModel(QAbstractItemModel):
             return QModelIndex(self.persistentIndexes[obj])
 
     def parent(self, index):
+        """
+        Returns parent of a given index.
+        If the index is invalid, then an invalid QModelIndex is returned.
+        Parent is decided on by checking the data type of the internal pointer
+        of the index.
+        Parameters
+        ----------
+        index : QModelIndex
+            Index to find parent index of.
+        Returns
+        -------
+        QModelIndex
+            Parent index.
+        """
         if not index.isValid():
             return QModelIndex()
         if isinstance(index.internalPointer(), (Instrument, Beam, Normalisation, SampleBackground)):
@@ -115,8 +150,21 @@ class GudPyTreeModel(QAbstractItemModel):
         elif isinstance(index.internalPointer(), Container):
             parent = self.findParent(index.internalPointer())
             return QModelIndex(self.persistentIndexes[parent])
+        else:
+            return QModelIndex()
     
     def findParent(self, item):
+        """
+        Finds the parent of a given Sample or Container.
+        Parameters
+        ----------
+        item : Sample | Container
+            Object to find parent of.
+        Returns
+        -------
+        SampleBackground | Sample
+            Parent object.
+        """
         for i, sampleBackground in enumerate(self.gudrunFile.sampleBackgrounds):
             if isinstance(item, Sample):
                 if item in sampleBackground.samples:
@@ -127,6 +175,24 @@ class GudPyTreeModel(QAbstractItemModel):
                         return self.gudrunFile.sampleBackgrounds[i].samples[j]
 
     def data(self, index, role):
+        """
+        Returns the data at a given index.
+        If the index is invalid, or the role is not
+        Qt.EditRole | Qt.DisplayRole | Qt.CheckStateRole, then an empty
+        QVariant is returned.
+        Otherwise returns check state of index, or a QVariant constructed
+        from its name.
+        Parameters
+        ----------
+        index : QModelIndex
+            Index to extract data from.
+        role : int
+            Role.
+        Returns
+        -------
+        QVariant | QCheckState
+            Data at index.
+        """
         if not index.isValid():
             return QVariant()
         if role == Qt.DisplayRole or role == Qt.EditRole:
@@ -137,8 +203,26 @@ class GudPyTreeModel(QAbstractItemModel):
                 return QVariant(index.internalPointer().name)
         elif role == Qt.CheckStateRole and self.isSample(index):
             return self.checkState(index)
+        else:
+            return QVariant()
 
     def setData(self, index, value, role):
+        """
+        Sets data at a given index, if the index is valid.
+        Only used for assigning CheckStates to samples.
+        Parameters
+        ----------
+        index : QModelIndex
+            Index to set data at.
+        value : QCheckState
+            Value to assign to data.
+        role : int
+            Role.
+        Returns
+        -------
+        bool
+            Success / Failure.
+        """
         if not index.isValid():
             return False
         elif role == Qt.CheckStateRole and self.isSample(index):
@@ -148,17 +232,45 @@ class GudPyTreeModel(QAbstractItemModel):
             return False
 
     def checkState(self, index):
+        """
+        Returns the check state of a given index.
+        Parameters
+        ----------
+        index : QModelIndex
+            Index to return check state from.
+        Returns
+        -------
+        QCheckState
+            Check state.
+        """
         return Qt.Checked if self.isIncluded(index) else Qt.Unchecked
 
     def rowCount(self, parent=QModelIndex()):
+        """
+        Returns the row count of a given parent index.
+        The row count returned depends on the data type of the parent.
+        Parameters
+        ----------
+        parent : QModelIndex
+            Parent index to retrieve row count from.
+        Returns
+        -------
+        int
+            Row count.
+        """
+        # If the parent is invalid, then it is a top level node.
         if not parent.isValid():
+            # Instrument + Beam + Normalisation + N SampleBackgrounds
             return 3 + len(self.gudrunFile.sampleBackgrounds)
         elif parent.isValid() and not parent.parent().isValid():
+            # If the parent is valid, but the grandparent is invalid
+            # Return the number of samples of the sample background.
             if parent.row() >= 3:
                 return len(self.gudrunFile.sampleBackgrounds[parent.row()-3].samples)
             else:
                 return 0
         elif parent.isValid() and parent.parent().isValid() and not parent.parent().parent().isValid():
+            # If it is a leaf, then return the number of containers for the sample.
             if parent.parent().row() >=3:
                 return len(self.gudrunFile.sampleBackgrounds[parent.parent().row()-3].samples[parent.row()].containers)
             else:
@@ -167,18 +279,63 @@ class GudPyTreeModel(QAbstractItemModel):
             return 0
 
     def columnCount(self, parent=QModelIndex()):
+        """
+        Returns the column count of an index.
+        Parameters
+        ----------
+        parent : QModelIndex
+            Parent index to retrieve column row count from.
+        Returns
+        -------
+        int
+            Column count. This is always 1.
+        """
         return 1
 
     def flags(self, index):
+        """
+        Returns flags associated with a given index.
+        Parameters
+        ----------
+        index : QModelIndex
+            Index to retreive flags from.
+        Returns
+        -------
+        int
+            Flags.
+        """
         flags = super(GudPyTreeModel, self).flags(index)
+        # If is is a sample, make append checkable flag.
         if self.isSample(index):
             flags |= Qt.ItemIsUserCheckable
         return flags
 
     def isSample(self, index):
+        """
+        Returns whether a given index is associated with a sample.
+        Parameters
+        ----------
+        index : QModelIndex
+            Index to check if sample is associated with.
+        Returns
+        -------
+        bool
+            Is it a sample or not?
+        """
         return isinstance(index.parent().internalPointer(), SampleBackground)
 
     def isIncluded(self, index):
+        """
+        Returns whether a given index of a sample is to be ran.
+        Parameters
+        ----------
+        index : QModelIndex
+            Index to check if the associated sample is to be included or not.
+        Returns
+        -------
+        bool
+            Is it to be included?
+        """
         return self.isSample(index) and index.internalPointer().runThisSample
 
 class GudPyTreeView(QTreeView):

--- a/src/gui/widgets/gudpy_tree.py
+++ b/src/gui/widgets/gudpy_tree.py
@@ -30,24 +30,24 @@ class GudPyTreeModel(QAbstractItemModel):
         key is a GudPy object, value is a QPersistentIndex.
     Methods
     -------
-    rowCount(parent)
-        Returns the row count of an index.
-    columnCount(parent)
-        Returns the column count of an index.
-    checkState(index)
-        Returns the check state of a given index.
-    data(index, role)
-        Returns the data at a given index.
     index(row, column, parent)
         Returns index associated with given row, column and parent.
     parent(index)
         Returns parent of a given index.
     findParent(item)
         Finds the parent of a given Sample or Container.
-    flags(index)
-        Returns flags associated with a given index.
+    data(index, role)
+        Returns the data at a given index.
     setData(index, value, role)
         Sets data at a given index.
+    checkState(index)
+        Returns the check state of a given index.
+    rowCount(parent)
+        Returns the row count of an index.
+    columnCount(parent)
+        Returns the column count of an index.
+    flags(index)
+        Returns flags associated with a given index.
     isSample(index)
         Returns whether a given index is associated with a sample.
     isIncluded(index)
@@ -404,7 +404,7 @@ class GudPyTreeView(QTreeView):
     absoluteIndex(modelIndex)
         Returns the 'absolute' index of a QModelIndex object.
     depth(modelIndex, depth)
-        Recursive method for calulcating the
+        Recursive method for calculating the
         depth in the tree of a QModelIndex object.
     """
 


### PR DESCRIPTION
- The `GudPyTreeView` has been modified to use a `GudPyTreeModel`, which inherits `QAbstractItemModel`.
- The model does not rely on an external tree to maintain itself, rather it utilises the `index` and `parent` methods.
- No longer need `GudPyNode` class to describe nodes in the tree.
- Implementation is in line with the goal of the `ModelView` architecture.

Closes #84.