### PR TITLE
Instrument Widget UI 

### DIFF
--- a/src/gui/widgets/instrument_widget.py
+++ b/src/gui/widgets/instrument_widget.py
@@ -1007,6 +1007,8 @@ class InstrumentWidget(QWidget):
         )
 
         # Setup the widgets and slots for the grouping parameter panel.
+
+        self.groupingParameterWidget.setVisible(False)
         self.updateGroupingParameterPanel()
         self.addGroupingParameterButton.clicked.connect(
             self.handleAddGroupingParameter

--- a/src/gui/widgets/ui_files/instrumentWidget.ui
+++ b/src/gui/widgets/ui_files/instrumentWidget.ui
@@ -23,7 +23,7 @@
    <item>
     <widget class="QGroupBox" name="configGroupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -118,7 +118,7 @@
    <item>
     <widget class="QGroupBox" name="monitorsGroupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -512,7 +512,7 @@
    <item>
     <widget class="QGroupBox" name="binningGroupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -1238,7 +1238,7 @@
    <item>
     <widget class="QGroupBox" name="otherGroupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -1258,11 +1258,8 @@
      <property name="title">
       <string>Other</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <property name="verticalSpacing">
-       <number>0</number>
-      </property>
-      <item row="0" column="0">
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
          <widget class="QLabel" name="dataFileDirectoryLabel">
@@ -1325,7 +1322,7 @@
         </item>
        </layout>
       </item>
-      <item row="1" column="0">
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_7">
         <item>
          <widget class="QLabel" name="detCalibrationLabel">
@@ -1371,7 +1368,7 @@
         </item>
        </layout>
       </item>
-      <item row="2" column="0">
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_8">
         <item>
          <widget class="QLabel" name="groupsFileLabel">
@@ -1452,7 +1449,7 @@
         </item>
        </layout>
       </item>
-      <item row="3" column="0">
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_9">
         <item>
          <widget class="QLabel" name="deadtimeFileLabel">
@@ -1492,7 +1489,7 @@
         </item>
        </layout>
       </item>
-      <item row="4" column="0">
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_10">
         <item>
          <widget class="QLabel" name="channelNosLabel">
@@ -1592,7 +1589,7 @@
         </item>
        </layout>
       </item>
-      <item row="5" column="0">
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_11">
         <item>
          <widget class="QLabel" name="wavelengthRangeLabel">
@@ -1694,7 +1691,7 @@
         </item>
        </layout>
       </item>
-      <item row="6" column="0">
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_12">
         <item>
          <widget class="QLabel" name="incidentFlightPathLabel">
@@ -1746,93 +1743,7 @@
         </item>
        </layout>
       </item>
-      <item row="8" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_14">
-        <item>
-         <widget class="QLabel" name="neutronScatteringParamsFileLabel">
-          <property name="minimumSize">
-           <size>
-            <width>220</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Neutron scattering params file</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="neutronScatteringParamsFileLineEdit">
-          <property name="minimumSize">
-           <size>
-            <width>223</width>
-            <height>25</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="browseNeutronScatteringParamsButton">
-          <property name="minimumSize">
-           <size>
-            <width>80</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Browse</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="9" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout_15">
-        <item>
-         <widget class="QLabel" name="nexusDefinitionFileLabel">
-          <property name="minimumSize">
-           <size>
-            <width>151</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>NeXus definition file</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="nexusDefintionFileLineEdit">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>223</width>
-            <height>25</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="browseNexusDefinitionButton">
-          <property name="minimumSize">
-           <size>
-            <width>80</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Browse</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="7" column="0">
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="outputDiagSpectrumLabel">
@@ -1890,8 +1801,107 @@
         </item>
        </layout>
       </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_14">
+        <item>
+         <widget class="QLabel" name="neutronScatteringParamsFileLabel">
+          <property name="minimumSize">
+           <size>
+            <width>220</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Neutron scattering params file</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="neutronScatteringParamsFileLineEdit">
+          <property name="minimumSize">
+           <size>
+            <width>223</width>
+            <height>25</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="browseNeutronScatteringParamsButton">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_15">
+        <item>
+         <widget class="QLabel" name="nexusDefinitionFileLabel">
+          <property name="minimumSize">
+           <size>
+            <width>151</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>NeXus definition file</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="nexusDefintionFileLineEdit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>223</width>
+            <height>25</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="browseNexusDefinitionButton">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/gui/widgets/ui_files/instrumentWidget.ui
+++ b/src/gui/widgets/ui_files/instrumentWidget.ui
@@ -6,386 +6,433 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>651</width>
-    <height>890</height>
+    <width>716</width>
+    <height>969</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <widget class="QGroupBox" name="configGroupBox">
-   <property name="geometry">
-    <rect>
-     <x>9</x>
-     <y>9</y>
-     <width>640</width>
-     <height>91</height>
-    </rect>
-   </property>
-   <property name="minimumSize">
-    <size>
-     <width>640</width>
-     <height>91</height>
-    </size>
-   </property>
-   <property name="maximumSize">
-    <size>
-     <width>561</width>
-     <height>91</height>
-    </size>
-   </property>
-   <property name="title">
-    <string>Instrument Configuration</string>
-   </property>
-   <layout class="QGridLayout" name="gridLayout">
-    <item row="0" column="0">
-     <widget class="QLabel" name="nameLabel">
-      <property name="minimumSize">
-       <size>
-        <width>131</width>
-        <height>16</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Instrument Name</string>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="1">
-     <widget class="QComboBox" name="nameComboBox">
-      <property name="minimumSize">
-       <size>
-        <width>104</width>
-        <height>26</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>171</width>
-        <height>26</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="configLabel">
-      <property name="minimumSize">
-       <size>
-        <width>141</width>
-        <height>21</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Instrument Config</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="1">
-     <widget class="QLineEdit" name="configLineEdit">
-      <property name="minimumSize">
-       <size>
-        <width>125</width>
-        <height>21</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="2">
-     <widget class="QPushButton" name="browseConfigButton">
-      <property name="minimumSize">
-       <size>
-        <width>87</width>
-        <height>21</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Browse</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
-  <widget class="QGroupBox" name="otherGroupBox">
-   <property name="geometry">
-    <rect>
-     <x>9</x>
-     <y>106</y>
-     <width>640</width>
-     <height>781</height>
-    </rect>
-   </property>
-   <property name="minimumSize">
-    <size>
-     <width>640</width>
-     <height>781</height>
-    </size>
-   </property>
-   <property name="maximumSize">
-    <size>
-     <width>62</width>
-     <height>781</height>
-    </size>
-   </property>
-   <property name="title">
-    <string>Other</string>
-   </property>
-   <layout class="QGridLayout" name="gridLayout_2">
-    <item row="0" column="6">
-     <widget class="QLineEdit" name="dataFileDirectoryLineEdit">
-      <property name="minimumSize">
-       <size>
-        <width>180</width>
-        <height>25</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="7">
-     <widget class="QLineEdit" name="detCalibrationLineEdit">
-      <property name="minimumSize">
-       <size>
-        <width>180</width>
-        <height>25</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="16" column="0" colspan="3">
-     <widget class="QRadioButton" name="wavelengthRadioButton">
-      <property name="minimumSize">
-       <size>
-        <width>125</width>
-        <height>23</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>wavelength [A]</string>
-      </property>
-      <attribute name="buttonGroup">
-       <string notr="true">scaleSelectionButtonGroup</string>
-      </attribute>
-     </widget>
-    </item>
-    <item row="0" column="0" colspan="2">
-     <widget class="QLabel" name="dataFileDirectoryLabel">
-      <property name="minimumSize">
-       <size>
-        <width>131</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Data File Directory</string>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="11" colspan="2">
-     <widget class="QPushButton" name="browseDataFileDirectoryButton">
-      <property name="minimumSize">
-       <size>
-        <width>80</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Browse</string>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="16" colspan="2">
-     <widget class="QComboBox" name="dataFileTypeCombo">
-      <property name="minimumSize">
-       <size>
-        <width>61</width>
-        <height>25</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0" colspan="3">
-     <widget class="QLabel" name="detCalibrationLabel">
-      <property name="minimumSize">
-       <size>
-        <width>171</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Detector Calibration File</string>
-      </property>
-     </widget>
-    </item>
-    <item row="14" column="0" colspan="3">
-     <widget class="QRadioButton" name="_QRadioButton">
-      <property name="minimumSize">
-       <size>
-        <width>81</width>
-        <height>23</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Q [1/A]</string>
-      </property>
-      <attribute name="buttonGroup">
-       <string notr="true">scaleSelectionButtonGroup</string>
-      </attribute>
-     </widget>
-    </item>
-    <item row="14" column="7" colspan="2">
-     <widget class="QDoubleSpinBox" name="maxQSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="14" column="9" colspan="3">
-     <widget class="QDoubleSpinBox" name="stepQSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="15" column="7" colspan="2">
-     <widget class="QDoubleSpinBox" name="maxDSpacingSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="15" column="0" colspan="3">
-     <widget class="QRadioButton" name="DSpacingRadioButton">
-      <property name="minimumSize">
-       <size>
-        <width>111</width>
-        <height>23</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>d-spacing [A]</string>
-      </property>
-      <attribute name="buttonGroup">
-       <string notr="true">scaleSelectionButtonGroup</string>
-      </attribute>
-     </widget>
-    </item>
-    <item row="13" column="0" colspan="5">
-     <widget class="QLabel" name="xScaleLabel">
-      <property name="minimumSize">
-       <size>
-        <width>144</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>X-scale for final DCS: </string>
-      </property>
-     </widget>
-    </item>
-    <item row="12" column="8">
-     <widget class="QSpinBox" name="noSmoothsOnMonitorSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="13" column="8">
-     <widget class="QLabel" name="maxXScaleLabel">
-      <property name="minimumSize">
-       <size>
-        <width>31</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>31</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Max</string>
-      </property>
-     </widget>
-    </item>
-    <item row="12" column="0" colspan="7">
-     <widget class="QLabel" name="noSmoothsOnMonitorLabel">
-      <property name="minimumSize">
-       <size>
-        <width>180</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>180</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>No. smooths on monitor</string>
-      </property>
-     </widget>
-    </item>
-    <item row="13" column="6">
-     <widget class="QLabel" name="minXScaleLabel">
-      <property name="minimumSize">
-       <size>
-        <width>31</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Min</string>
-      </property>
-     </widget>
-    </item>
-    <item row="13" column="9" colspan="3">
+  <layout class="QVBoxLayout" name="verticalLayout_4">
+   <item>
+    <widget class="QGroupBox" name="configGroupBox">
+     <property name="minimumSize">
+      <size>
+       <width>640</width>
+       <height>91</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>561</width>
+       <height>91</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Instrument Configuration</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="nameLabel">
+        <property name="minimumSize">
+         <size>
+          <width>131</width>
+          <height>16</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Instrument Name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="nameComboBox">
+        <property name="minimumSize">
+         <size>
+          <width>104</width>
+          <height>26</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>171</width>
+          <height>26</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="configLabel">
+        <property name="minimumSize">
+         <size>
+          <width>141</width>
+          <height>21</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Instrument Config</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="configLineEdit">
+        <property name="minimumSize">
+         <size>
+          <width>125</width>
+          <height>21</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QPushButton" name="browseConfigButton">
+        <property name="minimumSize">
+         <size>
+          <width>87</width>
+          <height>21</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Browse</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="monitorsGroupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>640</width>
+       <height>91</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Monitors</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="spectrumNumbersIBLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Spectrum numbers for beam monitors</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="spectrumNumbersIBLabel_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Indicent</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="spectrumNumbersTLineEdit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>91</width>
+            <height>25</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="spectrumNumbersTLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Transmission</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="spectrumNumbersIBLineEdit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>91</width>
+            <height>25</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="wavelengthRangeMonNormLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Wavelength range for monitor normalisation</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="minWavelengthMonNormSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>62</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>62</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="maxWavelengthMonNormSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>62</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="queitCountConstLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Quiet count const for beam monitors</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="queitCountConstLabel_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Incident</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="incidentMonitorQuietCountConstSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>62</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>62</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="queitCountConstTMLabel">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Transmission</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="transmissionMonitorQuietCountConstSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>63</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QLabel" name="noSmoothsOnMonitorLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>180</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>No. smooths on monitor</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="noSmoothsOnMonitorSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="binningGroupBox">
+     <property name="minimumSize">
+      <size>
+       <width>640</width>
+       <height>91</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Binning</string>
+     </property>
      <widget class="QLabel" name="stepXScaleLabel">
+      <property name="geometry">
+       <rect>
+        <x>329</x>
+        <y>23</y>
+        <width>43</width>
+        <height>25</height>
+       </rect>
+      </property>
       <property name="minimumSize">
        <size>
         <width>30</width>
@@ -402,406 +449,15 @@
        <string>Step size</string>
       </property>
      </widget>
-    </item>
-    <item row="13" column="12" colspan="6">
-     <widget class="QCheckBox" name="logarithmicBinningCheckBox">
-      <property name="minimumSize">
-       <size>
-        <width>180</width>
-        <height>23</height>
-       </size>
-      </property>
-      <property name="layoutDirection">
-       <enum>Qt::RightToLeft</enum>
-      </property>
-      <property name="text">
-       <string>Logarithmic binning?</string>
-      </property>
-     </widget>
-    </item>
-    <item row="22" column="13">
-     <widget class="QSpinBox" name="mergePowerSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="21" column="10">
-     <widget class="QLabel" name="groupsAcceptanceFactorLabel">
-      <property name="minimumSize">
-       <size>
-        <width>131</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Acceptance factor</string>
-      </property>
-     </widget>
-    </item>
-    <item row="22" column="10">
-     <widget class="QLabel" name="mergePowerLabel">
-      <property name="minimumSize">
-       <size>
-        <width>91</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Merge power</string>
-      </property>
-     </widget>
-    </item>
-    <item row="21" column="0" rowspan="4" colspan="9">
-     <widget class="GroupingParameterTable" name="groupingParameterTable">
-      <property name="minimumSize">
-       <size>
-        <width>270</width>
-        <height>113</height>
-       </size>
-      </property>
-      <property name="selectionBehavior">
-       <enum>QAbstractItemView::SelectRows</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="23" column="10">
-     <widget class="QLabel" name="incidentFlightPathLabel">
-      <property name="minimumSize">
-       <size>
-        <width>164</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Incident flight path [m]</string>
-      </property>
-     </widget>
-    </item>
-    <item row="25" column="12">
-     <widget class="QSpinBox" name="outputDiagSpectrumSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="16" column="5">
-     <widget class="QDoubleSpinBox" name="minWavelength_SpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="15" column="5">
-     <widget class="QDoubleSpinBox" name="minDSpacingSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="15" column="9" colspan="3">
-     <widget class="QDoubleSpinBox" name="stepDSpacingSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="20" column="0" colspan="7">
-     <widget class="QLabel" name="groupingParameterPanelLabel">
-      <property name="minimumSize">
-       <size>
-        <width>201</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Grouping Parameter Panel</string>
-      </property>
-     </widget>
-    </item>
-    <item row="21" column="15">
-     <widget class="QDoubleSpinBox" name="groupsAcceptanceFactorSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="22" column="9">
-     <widget class="QPushButton" name="addGroupingParameterButton">
-      <property name="maximumSize">
-       <size>
-        <width>30</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>+</string>
-      </property>
-     </widget>
-    </item>
-    <item row="22" column="15">
-     <widget class="QComboBox" name="mergeWeightsComboBox">
-      <property name="minimumSize">
-       <size>
-        <width>94</width>
-        <height>25</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="23" column="9">
-     <widget class="QPushButton" name="removeGroupingParameterButton">
-      <property name="maximumSize">
-       <size>
-        <width>30</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>-</string>
-      </property>
-     </widget>
-    </item>
-    <item row="23" column="16" colspan="2">
-     <widget class="QDoubleSpinBox" name="incidentFlightPathSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="24" column="10">
-     <widget class="QCheckBox" name="hardGroupEdgesCheckBox">
-      <property name="minimumSize">
-       <size>
-        <width>155</width>
-        <height>23</height>
-       </size>
-      </property>
-      <property name="layoutDirection">
-       <enum>Qt::RightToLeft</enum>
-      </property>
-      <property name="text">
-       <string>Hard group edges?</string>
-      </property>
-     </widget>
-    </item>
-    <item row="25" column="0" colspan="11">
-     <widget class="QLabel" name="outputDiagSpectrumLabel">
-      <property name="minimumSize">
-       <size>
-        <width>320</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Spectrum number for output diagnostic files</string>
-      </property>
-     </widget>
-    </item>
-    <item row="14" column="5">
-     <widget class="QDoubleSpinBox" name="minQSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="26" column="0" colspan="8">
-     <widget class="QLabel" name="neutronScatteringParamsFileLabel">
-      <property name="minimumSize">
-       <size>
-        <width>220</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Neutron scattering params file</string>
-      </property>
-     </widget>
-    </item>
-    <item row="27" column="15" colspan="2">
-     <widget class="QPushButton" name="browseNexusDefinitionButton">
-      <property name="minimumSize">
-       <size>
-        <width>80</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Browse</string>
-      </property>
-     </widget>
-    </item>
-    <item row="27" column="0" colspan="6">
-     <widget class="QLabel" name="nexusDefinitionFileLabel">
-      <property name="minimumSize">
-       <size>
-        <width>151</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>NeXus definition file</string>
-      </property>
-     </widget>
-    </item>
-    <item row="18" column="5">
-     <widget class="QDoubleSpinBox" name="minTOFSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="26" column="15" colspan="2">
-     <widget class="QPushButton" name="browseNeutronScatteringParamsButton">
-      <property name="minimumSize">
-       <size>
-        <width>80</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Browse</string>
-      </property>
-     </widget>
-    </item>
-    <item row="17" column="0">
-     <widget class="QRadioButton" name="energyRadioButton">
-      <property name="minimumSize">
-       <size>
+     <widget class="QRadioButton" name="TOFRadioButton">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>203</y>
         <width>121</width>
         <height>23</height>
-       </size>
+       </rect>
       </property>
-      <property name="text">
-       <string>energy [meV]</string>
-      </property>
-      <attribute name="buttonGroup">
-       <string notr="true">scaleSelectionButtonGroup</string>
-      </attribute>
-     </widget>
-    </item>
-    <item row="27" column="8" colspan="6">
-     <widget class="QLineEdit" name="nexusDefintionFileLineEdit">
-      <property name="minimumSize">
-       <size>
-        <width>223</width>
-        <height>25</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="26" column="8" colspan="6">
-     <widget class="QLineEdit" name="neutronScatteringParamsFileLineEdit">
-      <property name="minimumSize">
-       <size>
-        <width>223</width>
-        <height>25</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="3">
-     <widget class="QLineEdit" name="groupsFileLineEdit">
-      <property name="minimumSize">
-       <size>
-        <width>180</width>
-        <height>25</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="18" column="0">
-     <widget class="QRadioButton" name="TOFRadioButton">
       <property name="minimumSize">
        <size>
         <width>121</width>
@@ -815,12 +471,49 @@
        <string notr="true">scaleSelectionButtonGroup</string>
       </attribute>
      </widget>
-    </item>
-    <item row="17" column="5">
-     <widget class="QDoubleSpinBox" name="minEnergySpinBox">
+     <widget class="QLabel" name="xScaleLabel">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>23</y>
+        <width>144</width>
+        <height>25</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>144</width>
+        <height>25</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>144</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>X-scale for final DCS: </string>
+      </property>
+     </widget>
+     <widget class="QDoubleSpinBox" name="minTOFSpinBox">
       <property name="enabled">
        <bool>false</bool>
       </property>
+      <property name="geometry">
+       <rect>
+        <x>141</x>
+        <y>203</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
       <property name="minimumSize">
        <size>
         <width>62</width>
@@ -834,363 +527,62 @@
        </size>
       </property>
      </widget>
-    </item>
-    <item row="1" column="12" colspan="2">
-     <widget class="QPushButton" name="browseDetCalibrationButton">
+     <widget class="QLabel" name="minXScaleLabel">
+      <property name="geometry">
+       <rect>
+        <x>201</x>
+        <y>23</y>
+        <width>31</width>
+        <height>25</height>
+       </rect>
+      </property>
       <property name="minimumSize">
        <size>
-        <width>80</width>
+        <width>31</width>
+        <height>25</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Min</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="maxXScaleLabel">
+      <property name="geometry">
+       <rect>
+        <x>261</x>
+        <y>23</y>
+        <width>31</width>
+        <height>25</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>31</width>
         <height>25</height>
        </size>
       </property>
       <property name="maximumSize">
        <size>
-        <width>80</width>
+        <width>31</width>
         <height>16777215</height>
        </size>
       </property>
       <property name="text">
-       <string>Browse</string>
+       <string>Max</string>
       </property>
      </widget>
-    </item>
-    <item row="2" column="0">
-     <widget class="QLabel" name="groupsFileLabel">
-      <property name="minimumSize">
-       <size>
-        <width>81</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Groups File</string>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="0" colspan="5">
-     <widget class="QLabel" name="deadtimeFileLabel">
-      <property name="minimumSize">
-       <size>
-        <width>171</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Deadtime Constants File</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="12" colspan="5">
-     <widget class="QLabel" name="phiValuesColumnLabel">
-      <property name="minimumSize">
-       <size>
-        <width>160</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Column for Phi Values</string>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="7">
-     <widget class="QLineEdit" name="deadtimeFileLineEdit">
-      <property name="minimumSize">
-       <size>
-        <width>180</width>
-        <height>25</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="0" colspan="11">
-     <widget class="QLabel" name="spectrumNumbersIBLabel">
-      <property name="minimumSize">
-       <size>
-        <width>311</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Spectrum numbers for incident beam monitor</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="17">
-     <widget class="QSpinBox" name="phiValuesColumnSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="12" colspan="4">
-     <widget class="QPushButton" name="browseDeadtimeFileButton">
-      <property name="minimumSize">
-       <size>
-        <width>80</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Browse</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="9" colspan="3">
-     <widget class="QPushButton" name="browseGroupsFileButton">
-      <property name="minimumSize">
-       <size>
-        <width>80</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>80</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Browse</string>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="11" colspan="3">
-     <widget class="QLineEdit" name="spectrumNumbersIBLineEdit">
-      <property name="minimumSize">
-       <size>
-        <width>91</width>
-        <height>25</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="0" colspan="11">
-     <widget class="QLabel" name="spectrumNumbersTLabel">
-      <property name="minimumSize">
-       <size>
-        <width>311</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Spectrum numbers for transmission monitor</string>
-      </property>
-     </widget>
-    </item>
-    <item row="5" column="11" colspan="3">
-     <widget class="QLineEdit" name="spectrumNumbersTLineEdit">
-      <property name="minimumSize">
-       <size>
-        <width>91</width>
-        <height>25</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="0" colspan="11">
-     <widget class="QLabel" name="wavelengthRangeMonNormLabel">
-      <property name="minimumSize">
-       <size>
-        <width>311</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Wavelength range for monitor normalisation</string>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="11" colspan="2">
-     <widget class="QDoubleSpinBox" name="minWavelengthMonNormSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>16777215</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="6" column="15" colspan="2">
-     <widget class="QDoubleSpinBox" name="maxWavelengthMonNormSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="7" column="0" colspan="9">
-     <widget class="QLabel" name="queitCountConstLabel">
-      <property name="minimumSize">
-       <size>
-        <width>250</width>
-        <height>0</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Quiet count const: Incident monitor</string>
-      </property>
-     </widget>
-    </item>
-    <item row="9" column="0" colspan="8">
-     <widget class="QLabel" name="channelNosLabel">
-      <property name="minimumSize">
-       <size>
-        <width>160</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>200</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Channels for spike analysis</string>
-      </property>
-     </widget>
-    </item>
-    <item row="9" column="16">
-     <widget class="QDoubleSpinBox" name="acceptanceFactorSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="7" column="16" colspan="2">
-     <widget class="QDoubleSpinBox" name="transmissionMonitorQuietCountConstSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>63</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="11" column="12" colspan="2">
-     <widget class="QDoubleSpinBox" name="maxWavelengthSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="11" column="15" colspan="2">
-     <widget class="QDoubleSpinBox" name="stepWavelengthSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="11" column="0" colspan="10">
-     <widget class="QLabel" name="wavelengthRangeLabel">
-      <property name="minimumSize">
-       <size>
-        <width>281</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Wavelength range to use and step size</string>
-      </property>
-     </widget>
-    </item>
-    <item row="11" column="10">
-     <widget class="QDoubleSpinBox" name="minWavelengthSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="16" column="7">
-     <widget class="QDoubleSpinBox" name="maxWavelength_SpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="18" column="9">
      <widget class="QDoubleSpinBox" name="stepTOFSpinBox">
       <property name="enabled">
        <bool>false</bool>
       </property>
+      <property name="geometry">
+       <rect>
+        <x>329</x>
+        <y>203</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
       <property name="minimumSize">
        <size>
         <width>62</width>
@@ -1204,12 +596,18 @@
        </size>
       </property>
      </widget>
-    </item>
-    <item row="17" column="9">
-     <widget class="QDoubleSpinBox" name="stepEnergySpinBox">
+     <widget class="QDoubleSpinBox" name="stepDSpacingSpinBox">
       <property name="enabled">
        <bool>false</bool>
       </property>
+      <property name="geometry">
+       <rect>
+        <x>329</x>
+        <y>87</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
       <property name="minimumSize">
        <size>
         <width>62</width>
@@ -1223,31 +621,18 @@
        </size>
       </property>
      </widget>
-    </item>
-    <item row="18" column="7">
-     <widget class="QDoubleSpinBox" name="maxTOFSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="17" column="7">
      <widget class="QDoubleSpinBox" name="maxEnergySpinBox">
       <property name="enabled">
        <bool>false</bool>
       </property>
+      <property name="geometry">
+       <rect>
+        <x>261</x>
+        <y>174</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
       <property name="minimumSize">
        <size>
         <width>62</width>
@@ -1261,12 +646,356 @@
        </size>
       </property>
      </widget>
-    </item>
-    <item row="16" column="9">
+     <widget class="QDoubleSpinBox" name="maxTOFSpinBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>261</x>
+        <y>203</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+     </widget>
+     <widget class="QDoubleSpinBox" name="minWavelength_SpinBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>141</x>
+        <y>116</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+     </widget>
+     <widget class="QRadioButton" name="DSpacingRadioButton">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>87</y>
+        <width>111</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>111</width>
+        <height>23</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>d-spacing [A]</string>
+      </property>
+      <attribute name="buttonGroup">
+       <string notr="true">scaleSelectionButtonGroup</string>
+      </attribute>
+     </widget>
+     <widget class="QRadioButton" name="energyRadioButton">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>174</y>
+        <width>121</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>121</width>
+        <height>23</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>energy [meV]</string>
+      </property>
+      <attribute name="buttonGroup">
+       <string notr="true">scaleSelectionButtonGroup</string>
+      </attribute>
+     </widget>
+     <widget class="QDoubleSpinBox" name="stepQSpinBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>329</x>
+        <y>56</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+     </widget>
+     <widget class="QDoubleSpinBox" name="maxWavelength_SpinBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>261</x>
+        <y>116</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+     </widget>
+     <widget class="QDoubleSpinBox" name="maxQSpinBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>261</x>
+        <y>56</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+     </widget>
+     <widget class="QDoubleSpinBox" name="minEnergySpinBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>141</x>
+        <y>174</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+     </widget>
+     <widget class="QDoubleSpinBox" name="minQSpinBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>141</x>
+        <y>56</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+     </widget>
+     <widget class="QDoubleSpinBox" name="stepEnergySpinBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>329</x>
+        <y>174</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+     </widget>
+     <widget class="QRadioButton" name="wavelengthRadioButton">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>116</y>
+        <width>125</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>125</width>
+        <height>23</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>wavelength [A]</string>
+      </property>
+      <attribute name="buttonGroup">
+       <string notr="true">scaleSelectionButtonGroup</string>
+      </attribute>
+     </widget>
+     <widget class="QDoubleSpinBox" name="minDSpacingSpinBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>141</x>
+        <y>87</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+     </widget>
+     <widget class="QDoubleSpinBox" name="maxDSpacingSpinBox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>261</x>
+        <y>87</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>62</width>
+        <height>22</height>
+       </size>
+      </property>
+     </widget>
+     <widget class="QRadioButton" name="_QRadioButton">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>56</y>
+        <width>81</width>
+        <height>23</height>
+       </rect>
+      </property>
+      <property name="minimumSize">
+       <size>
+        <width>81</width>
+        <height>23</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Q [1/A]</string>
+      </property>
+      <attribute name="buttonGroup">
+       <string notr="true">scaleSelectionButtonGroup</string>
+      </attribute>
+     </widget>
      <widget class="QDoubleSpinBox" name="stepWavelength_SpinBox">
       <property name="enabled">
        <bool>false</bool>
       </property>
+      <property name="geometry">
+       <rect>
+        <x>329</x>
+        <y>116</y>
+        <width>62</width>
+        <height>22</height>
+       </rect>
+      </property>
       <property name="minimumSize">
        <size>
         <width>62</width>
@@ -1280,96 +1009,767 @@
        </size>
       </property>
      </widget>
-    </item>
-    <item row="0" column="15">
-     <widget class="QLabel" name="dataFileTypeLabel">
+     <widget class="QCheckBox" name="logarithmicBinningCheckBox">
+      <property name="geometry">
+       <rect>
+        <x>389</x>
+        <y>24</y>
+        <width>180</width>
+        <height>23</height>
+       </rect>
+      </property>
       <property name="minimumSize">
        <size>
-        <width>41</width>
-        <height>25</height>
+        <width>180</width>
+        <height>23</height>
        </size>
+      </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
       </property>
       <property name="text">
-       <string>Type</string>
+       <string>Logarithmic binning?</string>
       </property>
      </widget>
-    </item>
-    <item row="9" column="8">
-     <widget class="QSpinBox" name="channelNoASpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
+     <widget class="QCheckBox" name="hardGroupEdgesCheckBox">
+      <property name="geometry">
+       <rect>
+        <x>389</x>
+        <y>145</y>
+        <width>155</width>
+        <height>23</height>
+       </rect>
       </property>
-      <property name="maximumSize">
-       <size>
-        <width>42</width>
-        <height>16777215</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="9" column="10">
-     <widget class="QSpinBox" name="channelNoBSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>42</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>42</width>
-        <height>16777215</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="9" column="12">
-     <widget class="QLabel" name="acceptanceFactorLabel">
-      <property name="minimumSize">
-       <size>
-        <width>131</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Acceptance factor</string>
-      </property>
-     </widget>
-    </item>
-    <item row="7" column="9">
-     <widget class="QDoubleSpinBox" name="incidentMonitorQuietCountConstSpinBox">
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-    </item>
-    <item row="7" column="11">
-     <widget class="QLabel" name="queitCountConstTMLabel">
       <property name="minimumSize">
        <size>
         <width>155</width>
-        <height>25</height>
+        <height>23</height>
        </size>
       </property>
+      <property name="layoutDirection">
+       <enum>Qt::RightToLeft</enum>
+      </property>
       <property name="text">
-       <string>Transmission monitor</string>
+       <string>Hard group edges?</string>
       </property>
      </widget>
-    </item>
-   </layout>
-  </widget>
+     <widget class="QGroupBox" name="groupBox">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>232</y>
+        <width>328</width>
+        <height>141</height>
+       </rect>
+      </property>
+      <property name="title">
+       <string>Grouping Parameter Panel</string>
+      </property>
+      <property name="flat">
+       <bool>false</bool>
+      </property>
+      <property name="checkable">
+       <bool>true</bool>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <item>
+        <widget class="GroupingParameterTable" name="groupingParameterTable">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>270</width>
+           <height>113</height>
+          </size>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="QPushButton" name="addGroupingParameterButton">
+           <property name="maximumSize">
+            <size>
+             <width>30</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>+</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="removeGroupingParameterButton">
+           <property name="maximumSize">
+            <size>
+             <width>30</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>-</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="">
+      <property name="geometry">
+       <rect>
+        <x>449</x>
+        <y>54</y>
+        <width>241</width>
+        <height>27</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_16">
+       <item>
+        <widget class="QLabel" name="mergePowerLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>91</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Merge power</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="mergePowerSpinBox">
+         <property name="minimumSize">
+          <size>
+           <width>42</width>
+           <height>22</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="mergeWeightsComboBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>94</width>
+           <height>25</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="">
+      <property name="geometry">
+       <rect>
+        <x>449</x>
+        <y>87</y>
+        <width>201</width>
+        <height>27</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_17">
+       <item>
+        <widget class="QLabel" name="groupsAcceptanceFactorLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>131</width>
+           <height>25</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Acceptance factor</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QDoubleSpinBox" name="groupsAcceptanceFactorSpinBox">
+         <property name="minimumSize">
+          <size>
+           <width>62</width>
+           <height>22</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>42</width>
+           <height>22</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="otherGroupBox">
+     <property name="minimumSize">
+      <size>
+       <width>700</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>62</width>
+       <height>781</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Other</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <widget class="QLabel" name="dataFileDirectoryLabel">
+          <property name="minimumSize">
+           <size>
+            <width>131</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Data File Directory</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="dataFileDirectoryLineEdit">
+          <property name="minimumSize">
+           <size>
+            <width>180</width>
+            <height>25</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="browseDataFileDirectoryButton">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="dataFileTypeLabel">
+          <property name="minimumSize">
+           <size>
+            <width>41</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Type</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="dataFileTypeCombo">
+          <property name="minimumSize">
+           <size>
+            <width>61</width>
+            <height>25</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
+        <item>
+         <widget class="QLabel" name="detCalibrationLabel">
+          <property name="minimumSize">
+           <size>
+            <width>171</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Detector Calibration File</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="detCalibrationLineEdit">
+          <property name="minimumSize">
+           <size>
+            <width>180</width>
+            <height>25</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="browseDetCalibrationButton">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>80</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_8">
+        <item>
+         <widget class="QLabel" name="groupsFileLabel">
+          <property name="minimumSize">
+           <size>
+            <width>81</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Groups File</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="groupsFileLineEdit">
+          <property name="minimumSize">
+           <size>
+            <width>180</width>
+            <height>25</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="browseGroupsFileButton">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>80</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="phiValuesColumnLabel">
+          <property name="minimumSize">
+           <size>
+            <width>160</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Column for Phi Values</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="phiValuesColumnSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
+        <item>
+         <widget class="QLabel" name="deadtimeFileLabel">
+          <property name="minimumSize">
+           <size>
+            <width>171</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Deadtime Constants File</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="deadtimeFileLineEdit">
+          <property name="minimumSize">
+           <size>
+            <width>180</width>
+            <height>25</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="browseDeadtimeFileButton">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_10">
+        <item>
+         <widget class="QLabel" name="channelNosLabel">
+          <property name="minimumSize">
+           <size>
+            <width>160</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>200</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Channels for spike analysis</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="channelNoASpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="channelNoBSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="acceptanceFactorLabel">
+          <property name="minimumSize">
+           <size>
+            <width>131</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Acceptance factor</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="acceptanceFactorSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>62</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_11">
+        <item>
+         <widget class="QLabel" name="wavelengthRangeLabel">
+          <property name="minimumSize">
+           <size>
+            <width>281</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Wavelength range to use and step size</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="minWavelengthSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>62</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="maxWavelengthSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>62</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="stepWavelengthSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>62</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_12">
+        <item>
+         <widget class="QLabel" name="incidentFlightPathLabel">
+          <property name="minimumSize">
+           <size>
+            <width>164</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Incident flight path [m]</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="incidentFlightPathSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>62</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_13">
+        <item>
+         <widget class="QLabel" name="outputDiagSpectrumLabel">
+          <property name="minimumSize">
+           <size>
+            <width>320</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Spectrum number for output diagnostic files</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="outputDiagSpectrumSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_14">
+        <item>
+         <widget class="QLabel" name="neutronScatteringParamsFileLabel">
+          <property name="minimumSize">
+           <size>
+            <width>220</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Neutron scattering params file</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="neutronScatteringParamsFileLineEdit">
+          <property name="minimumSize">
+           <size>
+            <width>223</width>
+            <height>25</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="browseNeutronScatteringParamsButton">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_15">
+        <item>
+         <widget class="QLabel" name="nexusDefinitionFileLabel">
+          <property name="minimumSize">
+           <size>
+            <width>151</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>NeXus definition file</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="nexusDefintionFileLineEdit">
+          <property name="minimumSize">
+           <size>
+            <width>223</width>
+            <height>25</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="browseNexusDefinitionButton">
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Browse</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/gui/widgets/ui_files/instrumentWidget.ui
+++ b/src/gui/widgets/ui_files/instrumentWidget.ui
@@ -6,14 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>716</width>
+    <width>724</width>
     <height>969</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_4">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <widget class="QGroupBox" name="configGroupBox">
      <property name="minimumSize">
@@ -103,7 +109,7 @@
    <item>
     <widget class="QGroupBox" name="monitorsGroupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -123,292 +129,282 @@
      <property name="title">
       <string>Monitors</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="spectrumNumbersIBLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Spectrum numbers for beam monitors</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="spectrumNumbersIBLabel_2">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Indicent</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="spectrumNumbersTLineEdit">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>91</width>
-            <height>25</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="spectrumNumbersTLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Transmission</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="spectrumNumbersIBLineEdit">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>91</width>
-            <height>25</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-       </layout>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="5" colspan="2">
+       <widget class="QDoubleSpinBox" name="maxWavelengthMonNormSpinBox">
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>42</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLabel" name="wavelengthRangeMonNormLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Wavelength range for monitor normalisation</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QDoubleSpinBox" name="minWavelengthMonNormSpinBox">
-          <property name="minimumSize">
-           <size>
-            <width>62</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>62</width>
-            <height>16777215</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QDoubleSpinBox" name="maxWavelengthMonNormSpinBox">
-          <property name="minimumSize">
-           <size>
-            <width>62</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>42</width>
-            <height>22</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="3" column="1">
+       <widget class="QSpinBox" name="noSmoothsOnMonitorSpinBox">
+        <property name="minimumSize">
+         <size>
+          <width>42</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>42</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QLabel" name="queitCountConstLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Quiet count const for beam monitors</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="queitCountConstLabel_2">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Incident</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QDoubleSpinBox" name="incidentMonitorQuietCountConstSpinBox">
-          <property name="minimumSize">
-           <size>
-            <width>62</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>62</width>
-            <height>22</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="queitCountConstTMLabel">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Transmission</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QDoubleSpinBox" name="transmissionMonitorQuietCountConstSpinBox">
-          <property name="minimumSize">
-           <size>
-            <width>63</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>42</width>
-            <height>22</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="2" column="8">
+       <widget class="QDoubleSpinBox" name="transmissionMonitorQuietCountConstSpinBox">
+        <property name="minimumSize">
+         <size>
+          <width>63</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>42</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="QLabel" name="noSmoothsOnMonitorLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>180</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>No. smooths on monitor</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="noSmoothsOnMonitorSpinBox">
-          <property name="minimumSize">
-           <size>
-            <width>42</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>42</width>
-            <height>22</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-       </layout>
+      <item row="2" column="0" colspan="2">
+       <widget class="QLabel" name="queitCountConstLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Quiet count const for beam monitors</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="6" colspan="2">
+       <widget class="QLabel" name="queitCountConstTMLabel">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Transmission</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="4" colspan="2">
+       <widget class="QDoubleSpinBox" name="incidentMonitorQuietCountConstSpinBox">
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="spectrumNumbersIBLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Spectrum numbers for beam monitors</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4" colspan="3">
+       <widget class="QLineEdit" name="spectrumNumbersTLineEdit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>91</width>
+          <height>25</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2" colspan="2">
+       <widget class="QLabel" name="queitCountConstLabel_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Incident</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="noSmoothsOnMonitorLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>180</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>No. smooths on monitor</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3" colspan="2">
+       <widget class="QDoubleSpinBox" name="minWavelengthMonNormSpinBox">
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>16777215</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="9">
+       <widget class="QLineEdit" name="spectrumNumbersIBLineEdit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>91</width>
+          <height>25</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="7" colspan="2">
+       <widget class="QLabel" name="spectrumNumbersTLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Transmission</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2" colspan="2">
+       <widget class="QLabel" name="spectrumNumbersIBLabel_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Indicent</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="3">
+       <widget class="QLabel" name="wavelengthRangeMonNormLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Wavelength range for monitor normalisation</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
     <widget class="QGroupBox" name="binningGroupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
        <width>640</width>
@@ -424,813 +420,680 @@
      <property name="title">
       <string>Binning</string>
      </property>
-     <widget class="QLabel" name="stepXScaleLabel">
-      <property name="geometry">
-       <rect>
-        <x>329</x>
-        <y>23</y>
-        <width>43</width>
-        <height>25</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>30</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>61</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Step size</string>
-      </property>
-     </widget>
-     <widget class="QRadioButton" name="TOFRadioButton">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>203</y>
-        <width>121</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>121</width>
-        <height>23</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>TOF [mus]</string>
-      </property>
-      <attribute name="buttonGroup">
-       <string notr="true">scaleSelectionButtonGroup</string>
-      </attribute>
-     </widget>
-     <widget class="QLabel" name="xScaleLabel">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>23</y>
-        <width>144</width>
-        <height>25</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>144</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>144</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>X-scale for final DCS: </string>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="minTOFSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>141</x>
-        <y>203</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QLabel" name="minXScaleLabel">
-      <property name="geometry">
-       <rect>
-        <x>201</x>
-        <y>23</y>
-        <width>31</width>
-        <height>25</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>31</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Min</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="maxXScaleLabel">
-      <property name="geometry">
-       <rect>
-        <x>261</x>
-        <y>23</y>
-        <width>31</width>
-        <height>25</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>31</width>
-        <height>25</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>31</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Max</string>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="stepTOFSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>329</x>
-        <y>203</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="stepDSpacingSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>329</x>
-        <y>87</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="maxEnergySpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>261</x>
-        <y>174</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="maxTOFSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>261</x>
-        <y>203</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="minWavelength_SpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>141</x>
-        <y>116</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QRadioButton" name="DSpacingRadioButton">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>87</y>
-        <width>111</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>111</width>
-        <height>23</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>d-spacing [A]</string>
-      </property>
-      <attribute name="buttonGroup">
-       <string notr="true">scaleSelectionButtonGroup</string>
-      </attribute>
-     </widget>
-     <widget class="QRadioButton" name="energyRadioButton">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>174</y>
-        <width>121</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>121</width>
-        <height>23</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>energy [meV]</string>
-      </property>
-      <attribute name="buttonGroup">
-       <string notr="true">scaleSelectionButtonGroup</string>
-      </attribute>
-     </widget>
-     <widget class="QDoubleSpinBox" name="stepQSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>329</x>
-        <y>56</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="maxWavelength_SpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>261</x>
-        <y>116</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="maxQSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>261</x>
-        <y>56</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="minEnergySpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>141</x>
-        <y>174</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="minQSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>141</x>
-        <y>56</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="stepEnergySpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>329</x>
-        <y>174</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QRadioButton" name="wavelengthRadioButton">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>116</y>
-        <width>125</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>125</width>
-        <height>23</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>wavelength [A]</string>
-      </property>
-      <attribute name="buttonGroup">
-       <string notr="true">scaleSelectionButtonGroup</string>
-      </attribute>
-     </widget>
-     <widget class="QDoubleSpinBox" name="minDSpacingSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>141</x>
-        <y>87</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QDoubleSpinBox" name="maxDSpacingSpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>261</x>
-        <y>87</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QRadioButton" name="_QRadioButton">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>56</y>
-        <width>81</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>81</width>
-        <height>23</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Q [1/A]</string>
-      </property>
-      <attribute name="buttonGroup">
-       <string notr="true">scaleSelectionButtonGroup</string>
-      </attribute>
-     </widget>
-     <widget class="QDoubleSpinBox" name="stepWavelength_SpinBox">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="geometry">
-       <rect>
-        <x>329</x>
-        <y>116</y>
-        <width>62</width>
-        <height>22</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>62</width>
-        <height>22</height>
-       </size>
-      </property>
-     </widget>
-     <widget class="QCheckBox" name="logarithmicBinningCheckBox">
-      <property name="geometry">
-       <rect>
-        <x>389</x>
-        <y>24</y>
-        <width>180</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>180</width>
-        <height>23</height>
-       </size>
-      </property>
-      <property name="layoutDirection">
-       <enum>Qt::RightToLeft</enum>
-      </property>
-      <property name="text">
-       <string>Logarithmic binning?</string>
-      </property>
-     </widget>
-     <widget class="QCheckBox" name="hardGroupEdgesCheckBox">
-      <property name="geometry">
-       <rect>
-        <x>389</x>
-        <y>145</y>
-        <width>155</width>
-        <height>23</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>155</width>
-        <height>23</height>
-       </size>
-      </property>
-      <property name="layoutDirection">
-       <enum>Qt::RightToLeft</enum>
-      </property>
-      <property name="text">
-       <string>Hard group edges?</string>
-      </property>
-     </widget>
-     <widget class="QGroupBox" name="groupBox">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>232</y>
-        <width>328</width>
-        <height>141</height>
-       </rect>
-      </property>
-      <property name="title">
-       <string>Grouping Parameter Panel</string>
-      </property>
-      <property name="flat">
-       <bool>false</bool>
-      </property>
-      <property name="checkable">
-       <bool>true</bool>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_5">
-       <item>
-        <widget class="GroupingParameterTable" name="groupingParameterTable">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>270</width>
-           <height>113</height>
-          </size>
-         </property>
-         <property name="selectionBehavior">
-          <enum>QAbstractItemView::SelectRows</enum>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QPushButton" name="addGroupingParameterButton">
-           <property name="maximumSize">
-            <size>
-             <width>30</width>
-             <height>16777215</height>
-            </size>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="3" column="3">
+       <widget class="QDoubleSpinBox" name="stepDSpacingSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="stepXScaleLabel">
+        <property name="minimumSize">
+         <size>
+          <width>30</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>61</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Step size</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="4">
+       <widget class="QLabel" name="groupsAcceptanceFactorLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Acceptance factor</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="5">
+       <widget class="QSpinBox" name="mergePowerSpinBox">
+        <property name="minimumSize">
+         <size>
+          <width>42</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="minQSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QDoubleSpinBox" name="stepQSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QDoubleSpinBox" name="minDSpacingSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="5">
+       <widget class="QDoubleSpinBox" name="groupsAcceptanceFactorSpinBox">
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>42</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QRadioButton" name="energyRadioButton">
+        <property name="minimumSize">
+         <size>
+          <width>121</width>
+          <height>23</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>energy [meV]</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">scaleSelectionButtonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QRadioButton" name="wavelengthRadioButton">
+        <property name="minimumSize">
+         <size>
+          <width>125</width>
+          <height>23</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>wavelength [A]</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">scaleSelectionButtonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QCheckBox" name="logarithmicBinningCheckBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>23</height>
+         </size>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
+        <property name="text">
+         <string>Logarithmic binning?</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="maxXScaleLabel">
+        <property name="minimumSize">
+         <size>
+          <width>31</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>31</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Max</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5" colspan="2">
+       <widget class="QCheckBox" name="hardGroupEdgesCheckBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>23</height>
+         </size>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::RightToLeft</enum>
+        </property>
+        <property name="text">
+         <string>Hard group edges?</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QDoubleSpinBox" name="maxDSpacingSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QDoubleSpinBox" name="maxQSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="minXScaleLabel">
+        <property name="minimumSize">
+         <size>
+          <width>31</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Min</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QRadioButton" name="_QRadioButton">
+        <property name="minimumSize">
+         <size>
+          <width>81</width>
+          <height>23</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Q [1/A]</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">scaleSelectionButtonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="xScaleLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>144</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>144</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>X-scale for final DCS: </string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="6">
+       <widget class="QComboBox" name="mergeWeightsComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>94</width>
+          <height>25</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QRadioButton" name="DSpacingRadioButton">
+        <property name="minimumSize">
+         <size>
+          <width>111</width>
+          <height>23</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>d-spacing [A]</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">scaleSelectionButtonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="3" column="4">
+       <widget class="QLabel" name="mergePowerLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Merge power</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
+       <widget class="QRadioButton" name="TOFRadioButton">
+        <property name="minimumSize">
+         <size>
+          <width>121</width>
+          <height>23</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>TOF [mus]</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">scaleSelectionButtonGroup</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QDoubleSpinBox" name="minWavelength_SpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QDoubleSpinBox" name="minEnergySpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QDoubleSpinBox" name="minTOFSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="QDoubleSpinBox" name="maxWavelength_SpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2">
+       <widget class="QDoubleSpinBox" name="maxEnergySpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="2">
+       <widget class="QDoubleSpinBox" name="maxTOFSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
+       <widget class="QDoubleSpinBox" name="stepWavelength_SpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="3">
+       <widget class="QDoubleSpinBox" name="stepEnergySpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="3">
+       <widget class="QDoubleSpinBox" name="stepTOFSpinBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>62</width>
+          <height>22</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="4" colspan="3">
+       <widget class="QGroupBox" name="groupBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="title">
+         <string>Grouping Parameter Panel</string>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <item row="0" column="0">
+          <widget class="QWidget" name="groupingParameterWidget" native="true">
+           <property name="enabled">
+            <bool>true</bool>
            </property>
-           <property name="text">
-            <string>+</string>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="removeGroupingParameterButton">
-           <property name="maximumSize">
-            <size>
-             <width>30</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>-</string>
-           </property>
+           <widget class="GroupingParameterTable" name="groupingParameterTable">
+            <property name="geometry">
+             <rect>
+              <x>12</x>
+              <y>4</y>
+              <width>270</width>
+              <height>121</height>
+             </rect>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>270</width>
+              <height>113</height>
+             </size>
+            </property>
+            <property name="selectionBehavior">
+             <enum>QAbstractItemView::SelectRows</enum>
+            </property>
+           </widget>
+           <widget class="QWidget" name="">
+            <property name="geometry">
+             <rect>
+              <x>292</x>
+              <y>12</y>
+              <width>32</width>
+              <height>66</height>
+             </rect>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout">
+             <item>
+              <widget class="QPushButton" name="addGroupingParameterButton">
+               <property name="maximumSize">
+                <size>
+                 <width>30</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>+</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="removeGroupingParameterButton">
+               <property name="maximumSize">
+                <size>
+                 <width>30</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="text">
+                <string>-</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </widget>
          </item>
         </layout>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="">
-      <property name="geometry">
-       <rect>
-        <x>449</x>
-        <y>54</y>
-        <width>241</width>
-        <height>27</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_16">
-       <item>
-        <widget class="QLabel" name="mergePowerLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>91</width>
-           <height>25</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Merge power</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QSpinBox" name="mergePowerSpinBox">
-         <property name="minimumSize">
-          <size>
-           <width>42</width>
-           <height>22</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="mergeWeightsComboBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>94</width>
-           <height>25</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="">
-      <property name="geometry">
-       <rect>
-        <x>449</x>
-        <y>87</y>
-        <width>201</width>
-        <height>27</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_17">
-       <item>
-        <widget class="QLabel" name="groupsAcceptanceFactorLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>131</width>
-           <height>25</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Acceptance factor</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QDoubleSpinBox" name="groupsAcceptanceFactorSpinBox">
-         <property name="minimumSize">
-          <size>
-           <width>62</width>
-           <height>22</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>42</width>
-           <height>22</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
     <widget class="QGroupBox" name="otherGroupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
        <width>700</width>
@@ -1246,8 +1109,8 @@
      <property name="title">
       <string>Other</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <item>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
          <widget class="QLabel" name="dataFileDirectoryLabel">
@@ -1310,7 +1173,7 @@
         </item>
        </layout>
       </item>
-      <item>
+      <item row="1" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_7">
         <item>
          <widget class="QLabel" name="detCalibrationLabel">
@@ -1356,7 +1219,7 @@
         </item>
        </layout>
       </item>
-      <item>
+      <item row="2" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_8">
         <item>
          <widget class="QLabel" name="groupsFileLabel">
@@ -1431,7 +1294,7 @@
         </item>
        </layout>
       </item>
-      <item>
+      <item row="3" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_9">
         <item>
          <widget class="QLabel" name="deadtimeFileLabel">
@@ -1471,7 +1334,7 @@
         </item>
        </layout>
       </item>
-      <item>
+      <item row="4" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_10">
         <item>
          <widget class="QLabel" name="channelNosLabel">
@@ -1555,7 +1418,7 @@
         </item>
        </layout>
       </item>
-      <item>
+      <item row="5" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_11">
         <item>
          <widget class="QLabel" name="wavelengthRangeLabel">
@@ -1620,7 +1483,7 @@
         </item>
        </layout>
       </item>
-      <item>
+      <item row="6" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_12">
         <item>
          <widget class="QLabel" name="incidentFlightPathLabel">
@@ -1653,10 +1516,16 @@
         </item>
        </layout>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_13">
+      <item row="7" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QLabel" name="outputDiagSpectrumLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
             <width>320</width>
@@ -1686,7 +1555,7 @@
         </item>
        </layout>
       </item>
-      <item>
+      <item row="8" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_14">
         <item>
          <widget class="QLabel" name="neutronScatteringParamsFileLabel">
@@ -1726,7 +1595,7 @@
         </item>
        </layout>
       </item>
-      <item>
+      <item row="9" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_15">
         <item>
          <widget class="QLabel" name="nexusDefinitionFileLabel">

--- a/src/gui/widgets/ui_files/instrumentWidget.ui
+++ b/src/gui/widgets/ui_files/instrumentWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>724</width>
-    <height>800</height>
+    <height>912</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -140,97 +140,118 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLabel" name="spectrumNumbersIBLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Spectrum numbers for beam monitors</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="spectrumNumbersIBLabel_2">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Indicent</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="spectrumNumbersTLineEdit">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>91</width>
-            <height>25</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="spectrumNumbersTLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>25</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Transmission</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLineEdit" name="spectrumNumbersIBLineEdit">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>91</width>
-            <height>25</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-       </layout>
+       <widget class="QGroupBox" name="groupBox_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>71</height>
+         </size>
+        </property>
+        <property name="title">
+         <string>Spectrum Numbers for Beam Monitors</string>
+        </property>
+        <widget class="QWidget" name="">
+         <property name="geometry">
+          <rect>
+           <x>15</x>
+           <y>33</y>
+           <width>640</width>
+           <height>27</height>
+          </rect>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QLabel" name="spectrumNumbersIBLabel_2">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>25</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Indicent</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="spectrumNumbersTLineEdit">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>91</width>
+              <height>25</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="spectrumNumbersTLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>25</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Transmission</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="spectrumNumbersIBLineEdit">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>91</width>
+              <height>25</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_6">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </widget>
       </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -1164,7 +1185,7 @@
                  <enum>QAbstractItemView::SelectRows</enum>
                 </property>
                </widget>
-               <widget class="QWidget" name="">
+               <widget class="QWidget" name="layoutWidget">
                 <property name="geometry">
                  <rect>
                   <x>292</x>

--- a/src/gui/widgets/ui_files/instrumentWidget.ui
+++ b/src/gui/widgets/ui_files/instrumentWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>724</width>
-    <height>969</height>
+    <height>800</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,9 +19,15 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout_5">
    <item>
     <widget class="QGroupBox" name="configGroupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="minimumSize">
       <size>
        <width>640</width>
@@ -38,6 +44,9 @@
       <string>Instrument Configuration</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <property name="verticalSpacing">
+       <number>0</number>
+      </property>
       <item row="0" column="0">
        <widget class="QLabel" name="nameLabel">
         <property name="minimumSize">
@@ -67,20 +76,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="configLabel">
-        <property name="minimumSize">
-         <size>
-          <width>141</width>
-          <height>21</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Instrument Config</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
+      <item row="3" column="1">
        <widget class="QLineEdit" name="configLineEdit">
         <property name="minimumSize">
          <size>
@@ -90,7 +86,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
+      <item row="3" column="2">
        <widget class="QPushButton" name="browseConfigButton">
         <property name="minimumSize">
          <size>
@@ -103,13 +99,26 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="configLabel">
+        <property name="minimumSize">
+         <size>
+          <width>141</width>
+          <height>21</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Instrument Config</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
    <item>
     <widget class="QGroupBox" name="monitorsGroupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -117,7 +126,7 @@
      <property name="minimumSize">
       <size>
        <width>640</width>
-       <height>91</height>
+       <height>200</height>
       </size>
      </property>
      <property name="maximumSize">
@@ -129,270 +138,352 @@
      <property name="title">
       <string>Monitors</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="5" colspan="2">
-       <widget class="QDoubleSpinBox" name="maxWavelengthMonNormSpinBox">
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>42</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="spectrumNumbersIBLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Spectrum numbers for beam monitors</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="spectrumNumbersIBLabel_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Indicent</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="spectrumNumbersTLineEdit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>91</width>
+            <height>25</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="spectrumNumbersTLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Transmission</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="spectrumNumbersIBLineEdit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>91</width>
+            <height>25</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="3" column="1">
-       <widget class="QSpinBox" name="noSmoothsOnMonitorSpinBox">
-        <property name="minimumSize">
-         <size>
-          <width>42</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>42</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="wavelengthRangeMonNormLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Wavelength range for monitor normalisation</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="minWavelengthMonNormSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>62</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>62</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="maxWavelengthMonNormSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>62</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_8">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
-      <item row="2" column="8">
-       <widget class="QDoubleSpinBox" name="transmissionMonitorQuietCountConstSpinBox">
-        <property name="minimumSize">
-         <size>
-          <width>63</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>42</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QLabel" name="queitCountConstLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Quiet count const for beam monitors</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="queitCountConstLabel_2">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Incident</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="incidentMonitorQuietCountConstSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>62</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="queitCountConstTMLabel">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Transmission</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QDoubleSpinBox" name="transmissionMonitorQuietCountConstSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>63</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_9">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
-      <item row="2" column="0" colspan="2">
-       <widget class="QLabel" name="queitCountConstLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Quiet count const for beam monitors</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="6" colspan="2">
-       <widget class="QLabel" name="queitCountConstTMLabel">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Transmission</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="4" colspan="2">
-       <widget class="QDoubleSpinBox" name="incidentMonitorQuietCountConstSpinBox">
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="spectrumNumbersIBLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Spectrum numbers for beam monitors</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4" colspan="3">
-       <widget class="QLineEdit" name="spectrumNumbersTLineEdit">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>91</width>
-          <height>25</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2" colspan="2">
-       <widget class="QLabel" name="queitCountConstLabel_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Incident</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="noSmoothsOnMonitorLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>180</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>No. smooths on monitor</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3" colspan="2">
-       <widget class="QDoubleSpinBox" name="minWavelengthMonNormSpinBox">
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>16777215</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="9">
-       <widget class="QLineEdit" name="spectrumNumbersIBLineEdit">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>91</width>
-          <height>25</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="7" colspan="2">
-       <widget class="QLabel" name="spectrumNumbersTLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Transmission</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2" colspan="2">
-       <widget class="QLabel" name="spectrumNumbersIBLabel_2">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Indicent</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="3">
-       <widget class="QLabel" name="wavelengthRangeMonNormLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Wavelength range for monitor normalisation</string>
-        </property>
-       </widget>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QLabel" name="noSmoothsOnMonitorLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>180</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>No. smooths on monitor</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="noSmoothsOnMonitorSpinBox">
+          <property name="minimumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::MinimumExpanding</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -400,15 +491,15 @@
    <item>
     <widget class="QGroupBox" name="binningGroupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="minimumSize">
       <size>
-       <width>640</width>
-       <height>91</height>
+       <width>0</width>
+       <height>200</height>
       </size>
      </property>
      <property name="maximumSize">
@@ -420,668 +511,705 @@
      <property name="title">
       <string>Binning</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_4">
-      <item row="3" column="3">
-       <widget class="QDoubleSpinBox" name="stepDSpacingSpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_13">
+        <item>
+         <widget class="QLabel" name="xScaleLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>144</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>144</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>X-scale for final DCS: </string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="minXScaleLabel">
+          <property name="minimumSize">
+           <size>
+            <width>31</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Min</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="maxXScaleLabel">
+          <property name="minimumSize">
+           <size>
+            <width>31</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>31</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Max</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="logarithmicBinningCheckBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::RightToLeft</enum>
+          </property>
+          <property name="text">
+           <string>Logarithmic binning?</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="stepXScaleLabel">
+          <property name="minimumSize">
+           <size>
+            <width>30</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>61</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Step size</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="hardGroupEdgesCheckBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>23</height>
+           </size>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::RightToLeft</enum>
+          </property>
+          <property name="text">
+           <string>Hard group edges?</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="0" column="3">
-       <widget class="QLabel" name="stepXScaleLabel">
-        <property name="minimumSize">
-         <size>
-          <width>30</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>61</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Step size</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="4">
-       <widget class="QLabel" name="groupsAcceptanceFactorLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Acceptance factor</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="5">
-       <widget class="QSpinBox" name="mergePowerSpinBox">
-        <property name="minimumSize">
-         <size>
-          <width>42</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="minQSpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QDoubleSpinBox" name="stepQSpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QDoubleSpinBox" name="minDSpacingSpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="5">
-       <widget class="QDoubleSpinBox" name="groupsAcceptanceFactorSpinBox">
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>42</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QRadioButton" name="energyRadioButton">
-        <property name="minimumSize">
-         <size>
-          <width>121</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>energy [meV]</string>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">scaleSelectionButtonGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QRadioButton" name="wavelengthRadioButton">
-        <property name="minimumSize">
-         <size>
-          <width>125</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>wavelength [A]</string>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">scaleSelectionButtonGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item row="0" column="4">
-       <widget class="QCheckBox" name="logarithmicBinningCheckBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::RightToLeft</enum>
-        </property>
-        <property name="text">
-         <string>Logarithmic binning?</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="maxXScaleLabel">
-        <property name="minimumSize">
-         <size>
-          <width>31</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>31</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Max</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="5" colspan="2">
-       <widget class="QCheckBox" name="hardGroupEdgesCheckBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::RightToLeft</enum>
-        </property>
-        <property name="text">
-         <string>Hard group edges?</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QDoubleSpinBox" name="maxDSpacingSpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QDoubleSpinBox" name="maxQSpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLabel" name="minXScaleLabel">
-        <property name="minimumSize">
-         <size>
-          <width>31</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Min</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QRadioButton" name="_QRadioButton">
-        <property name="minimumSize">
-         <size>
-          <width>81</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Q [1/A]</string>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">scaleSelectionButtonGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="xScaleLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>144</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>144</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>X-scale for final DCS: </string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="6">
-       <widget class="QComboBox" name="mergeWeightsComboBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>94</width>
-          <height>25</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QRadioButton" name="DSpacingRadioButton">
-        <property name="minimumSize">
-         <size>
-          <width>111</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>d-spacing [A]</string>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">scaleSelectionButtonGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item row="3" column="4">
-       <widget class="QLabel" name="mergePowerLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>25</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Merge power</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QRadioButton" name="TOFRadioButton">
-        <property name="minimumSize">
-         <size>
-          <width>121</width>
-          <height>23</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>TOF [mus]</string>
-        </property>
-        <attribute name="buttonGroup">
-         <string notr="true">scaleSelectionButtonGroup</string>
-        </attribute>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QDoubleSpinBox" name="minWavelength_SpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="1">
-       <widget class="QDoubleSpinBox" name="minEnergySpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
-       <widget class="QDoubleSpinBox" name="minTOFSpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="2">
-       <widget class="QDoubleSpinBox" name="maxWavelength_SpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="2">
-       <widget class="QDoubleSpinBox" name="maxEnergySpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="2">
-       <widget class="QDoubleSpinBox" name="maxTOFSpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="3">
-       <widget class="QDoubleSpinBox" name="stepWavelength_SpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="3">
-       <widget class="QDoubleSpinBox" name="stepEnergySpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="3">
-       <widget class="QDoubleSpinBox" name="stepTOFSpinBox">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>62</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="4" colspan="3">
-       <widget class="QGroupBox" name="groupBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="title">
-         <string>Grouping Parameter Panel</string>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_3">
-         <item row="0" column="0">
-          <widget class="QWidget" name="groupingParameterWidget" native="true">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <widget class="GroupingParameterTable" name="groupingParameterTable">
-            <property name="geometry">
-             <rect>
-              <x>12</x>
-              <y>4</y>
-              <width>270</width>
-              <height>121</height>
-             </rect>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_18">
+        <item>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <widget class="QRadioButton" name="_QRadioButton">
+            <property name="minimumSize">
+             <size>
+              <width>81</width>
+              <height>23</height>
+             </size>
             </property>
+            <property name="text">
+             <string>Q [1/A]</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">scaleSelectionButtonGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="minQSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QDoubleSpinBox" name="maxQSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <widget class="QDoubleSpinBox" name="stepQSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QRadioButton" name="DSpacingRadioButton">
+            <property name="minimumSize">
+             <size>
+              <width>111</width>
+              <height>23</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>d-spacing [A]</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">scaleSelectionButtonGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QDoubleSpinBox" name="minDSpacingSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QDoubleSpinBox" name="maxDSpacingSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="QDoubleSpinBox" name="stepDSpacingSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QRadioButton" name="wavelengthRadioButton">
+            <property name="minimumSize">
+             <size>
+              <width>125</width>
+              <height>23</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>wavelength [A]</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">scaleSelectionButtonGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="minWavelength_SpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QDoubleSpinBox" name="maxWavelength_SpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="3">
+           <widget class="QDoubleSpinBox" name="stepWavelength_SpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QRadioButton" name="energyRadioButton">
+            <property name="minimumSize">
+             <size>
+              <width>121</width>
+              <height>23</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>energy [meV]</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">scaleSelectionButtonGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="minEnergySpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QDoubleSpinBox" name="maxEnergySpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QDoubleSpinBox" name="stepEnergySpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QRadioButton" name="TOFRadioButton">
+            <property name="minimumSize">
+             <size>
+              <width>121</width>
+              <height>23</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>TOF [mus]</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">scaleSelectionButtonGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QDoubleSpinBox" name="minTOFSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QDoubleSpinBox" name="maxTOFSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="3">
+           <widget class="QDoubleSpinBox" name="stepTOFSpinBox">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>62</width>
+              <height>22</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_16">
+            <item>
+             <widget class="QLabel" name="groupsAcceptanceFactorLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Acceptance factor</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QDoubleSpinBox" name="groupsAcceptanceFactorSpinBox">
+              <property name="minimumSize">
+               <size>
+                <width>62</width>
+                <height>22</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>42</width>
+                <height>22</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_17">
+            <item>
+             <widget class="QLabel" name="mergePowerLabel">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>25</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Merge power</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="mergePowerSpinBox">
+              <property name="minimumSize">
+               <size>
+                <width>42</width>
+                <height>22</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="mergeWeightsComboBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>94</width>
+                <height>25</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="groupBox">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="minimumSize">
-             <size>
-              <width>270</width>
-              <height>113</height>
-             </size>
+            <property name="title">
+             <string>Grouping Parameter Panel</string>
             </property>
-            <property name="selectionBehavior">
-             <enum>QAbstractItemView::SelectRows</enum>
+            <property name="flat">
+             <bool>false</bool>
             </property>
-           </widget>
-           <widget class="QWidget" name="">
-            <property name="geometry">
-             <rect>
-              <x>292</x>
-              <y>12</y>
-              <width>32</width>
-              <height>66</height>
-             </rect>
+            <property name="checkable">
+             <bool>true</bool>
             </property>
-            <layout class="QVBoxLayout" name="verticalLayout">
-             <item>
-              <widget class="QPushButton" name="addGroupingParameterButton">
-               <property name="maximumSize">
-                <size>
-                 <width>30</width>
-                 <height>16777215</height>
-                </size>
+            <layout class="QGridLayout" name="gridLayout_3">
+             <item row="0" column="0">
+              <widget class="QWidget" name="groupingParameterWidget" native="true">
+               <property name="enabled">
+                <bool>true</bool>
                </property>
-               <property name="text">
-                <string>+</string>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
                </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="removeGroupingParameterButton">
-               <property name="maximumSize">
-                <size>
-                 <width>30</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="text">
-                <string>-</string>
-               </property>
+               <widget class="GroupingParameterTable" name="groupingParameterTable">
+                <property name="geometry">
+                 <rect>
+                  <x>12</x>
+                  <y>4</y>
+                  <width>270</width>
+                  <height>121</height>
+                 </rect>
+                </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>270</width>
+                  <height>113</height>
+                 </size>
+                </property>
+                <property name="selectionBehavior">
+                 <enum>QAbstractItemView::SelectRows</enum>
+                </property>
+               </widget>
+               <widget class="QWidget" name="">
+                <property name="geometry">
+                 <rect>
+                  <x>292</x>
+                  <y>12</y>
+                  <width>32</width>
+                  <height>66</height>
+                 </rect>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout">
+                 <item>
+                  <widget class="QPushButton" name="addGroupingParameterButton">
+                   <property name="maximumSize">
+                    <size>
+                     <width>30</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>+</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="removeGroupingParameterButton">
+                   <property name="maximumSize">
+                    <size>
+                     <width>30</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>-</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
               </widget>
              </item>
             </layout>
            </widget>
-          </widget>
-         </item>
-        </layout>
-       </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -1089,7 +1217,7 @@
    <item>
     <widget class="QGroupBox" name="otherGroupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -1109,7 +1237,10 @@
      <property name="title">
       <string>Other</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_5">
+     <layout class="QGridLayout" name="gridLayout_4">
+      <property name="verticalSpacing">
+       <number>0</number>
+      </property>
       <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_6">
         <item>
@@ -1278,6 +1409,12 @@
         </item>
         <item>
          <widget class="QSpinBox" name="phiValuesColumnSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
             <width>42</width>
@@ -1286,8 +1423,8 @@
           </property>
           <property name="maximumSize">
            <size>
-            <width>42</width>
-            <height>22</height>
+            <width>16777215</width>
+            <height>16777215</height>
            </size>
           </property>
          </widget>
@@ -1416,15 +1553,37 @@
           </property>
          </widget>
         </item>
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::MinimumExpanding</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
        </layout>
       </item>
       <item row="5" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_11">
         <item>
          <widget class="QLabel" name="wavelengthRangeLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
-            <width>281</width>
+            <width>0</width>
             <height>25</height>
            </size>
           </property>
@@ -1434,7 +1593,26 @@
          </widget>
         </item>
         <item>
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
          <widget class="QDoubleSpinBox" name="minWavelengthSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
             <width>62</width>
@@ -1443,14 +1621,20 @@
           </property>
           <property name="maximumSize">
            <size>
-            <width>42</width>
-            <height>22</height>
+            <width>16777215</width>
+            <height>16777215</height>
            </size>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QDoubleSpinBox" name="maxWavelengthSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
             <width>62</width>
@@ -1459,14 +1643,20 @@
           </property>
           <property name="maximumSize">
            <size>
-            <width>42</width>
-            <height>22</height>
+            <width>16777215</width>
+            <height>16777215</height>
            </size>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QDoubleSpinBox" name="stepWavelengthSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
             <width>62</width>
@@ -1475,8 +1665,8 @@
           </property>
           <property name="maximumSize">
            <size>
-            <width>42</width>
-            <height>22</height>
+            <width>16777215</width>
+            <height>16777215</height>
            </size>
           </property>
          </widget>
@@ -1500,6 +1690,12 @@
         </item>
         <item>
          <widget class="QDoubleSpinBox" name="incidentFlightPathSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
             <width>62</width>
@@ -1508,50 +1704,24 @@
           </property>
           <property name="maximumSize">
            <size>
-            <width>42</width>
-            <height>22</height>
+            <width>16777215</width>
+            <height>16777215</height>
            </size>
           </property>
          </widget>
         </item>
-       </layout>
-      </item>
-      <item row="7" column="0">
-       <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
-         <widget class="QLabel" name="outputDiagSpectrumLabel">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+         <spacer name="horizontalSpacer_5">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-          <property name="minimumSize">
+          <property name="sizeHint" stdset="0">
            <size>
-            <width>320</width>
-            <height>25</height>
+            <width>338</width>
+            <height>20</height>
            </size>
           </property>
-          <property name="text">
-           <string>Spectrum number for output diagnostic files</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="outputDiagSpectrumSpinBox">
-          <property name="minimumSize">
-           <size>
-            <width>42</width>
-            <height>22</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>42</width>
-            <height>22</height>
-           </size>
-          </property>
-         </widget>
+         </spacer>
         </item>
        </layout>
       </item>
@@ -1612,6 +1782,12 @@
         </item>
         <item>
          <widget class="QLineEdit" name="nexusDefintionFileLineEdit">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
             <width>223</width>
@@ -1632,6 +1808,64 @@
            <string>Browse</string>
           </property>
          </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="7" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="outputDiagSpectrumLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>320</width>
+            <height>25</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Spectrum number for output diagnostic files</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QSpinBox" name="outputDiagSpectrumSpinBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>42</width>
+            <height>22</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>88</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </item>


### PR DESCRIPTION
Reorganised the general layout of the `InstrumentWidget`, and split up the fields into further categories (`config/monitors/binning/other`).

Took a more hierarchical approach to layouts - used horizontal layouts inside vertical layouts etc.

Aims to close #78 - however to main aim of this PR is to first ensure that we are on the right track following the feedback of #75. 