### PR TITLE
Tree context menu

### DIFF
--- a/src/gui/widgets/gudpy_tree.py
+++ b/src/gui/widgets/gudpy_tree.py
@@ -1,4 +1,5 @@
-from PyQt5.QtWidgets import QTreeView
+from PyQt5.QtGui import QCursor
+from PyQt5.QtWidgets import QAction, QMenu, QTreeView
 from PyQt5.QtCore import (
     QAbstractItemModel,
     QModelIndex,
@@ -568,6 +569,12 @@ class GudPyTreeView(QTreeView):
         Inserts an object into the current row in the model.
     removeRow()
         Removes the current index from the model.
+    insertSampleBackground_(sampleBackground)
+        Inserts a SampleBackground into the GudrunFile.
+    insertSample_(sample)
+        Inserts a Sample into the GudrunFile.
+    insertContainer_(container)
+        Inserts a Container into the GudrunFile.
     """
 
     def __init__(self, parent):
@@ -654,3 +661,76 @@ class GudPyTreeView(QTreeView):
         Removes the current index from the model.
         """
         self.model().removeRow(self.currentIndex())
+
+    def contextMenuEvent(self, event):
+        """
+        Creates context menu, so that on right clicking the table,
+        the user is able to perform menu actions.
+        Parameters
+        ----------
+        event : QMouseEvent
+            The event that triggers the context menu.
+        """
+        self.menu = QMenu(self)
+        editMenu = self.menu.addMenu("Edit")
+        insertSampleBackground = QAction("Insert Sample Background", editMenu)
+        insertSampleBackground.triggered.connect(
+            self.insertSampleBackground
+        )
+        editMenu.addAction(insertSampleBackground)
+        if isinstance(self.currentObject(), SampleBackground):
+            insertSample = QAction("Insert Sample", editMenu)
+            insertSample.triggered.connect(
+                self.insertSample
+            )
+            editMenu.addAction(insertSample)
+        elif isinstance(self.currentObject(), Sample):
+            insertContainer = QAction("Insert Container", editMenu)
+            insertContainer.triggered.connect(
+                self.insertContainer
+            )
+            editMenu.addAction(insertContainer)
+
+        self.menu.popup(QCursor.pos())
+
+    def insertSampleBackground(self, sampleBackground=None):
+        """
+        Inserts a SampleBackground into the GudrunFile.
+        Inserts it into the tree.
+        Parameters
+        ----------
+        sampleBackground : SampleBackground, optional
+            SampleBackground object to insert.
+        """
+        if not sampleBackground:
+            sampleBackground = SampleBackground()
+        self.insertRow(sampleBackground)
+
+    def insertSample(self, sample=None):
+        """
+        Inserts a Sample into the GudrunFile.
+        Inserts it into the tree.
+        Parameters
+        ----------
+        sample : Sample, optional
+            Sample object to insert.
+        """
+        if not sample:
+            sample = Sample()
+            sample.name = "SAMPLE"  # for now, give a default name.
+        self.insertRow(sample)
+
+    def insertContainer(self, container=None):
+        """
+        Inserts a Container into the GudrunFile.
+        Inserts it into the tree.
+        Parameters
+        ----------
+        container : Container, optional
+            Container object to insert.
+        """
+        if not container:
+            container = Container()
+            container.name = "CONTAINER"  # for now, give a default name.
+        self.insertRow(container)
+    

--- a/src/gui/widgets/gudpy_tree.py
+++ b/src/gui/widgets/gudpy_tree.py
@@ -16,6 +16,7 @@ from src.gudrun_classes.container import Container
 from src.gudrun_classes.config import NUM_GUDPY_CORE_OBJECTS
 from copy import deepcopy
 
+
 class GudPyTreeModel(QAbstractItemModel):
     """
     Class to represent a GudPyTreeModel. To be used with a GudyTree object.
@@ -680,25 +681,35 @@ class GudPyTreeView(QTreeView):
         """
         self.menu = QMenu(self)
         editMenu = self.menu.addMenu("Edit")
-        insertSampleBackground = QAction("Insert Sample Background", editMenu)
-        insertSampleBackground.triggered.connect(
-            self.insertSampleBackground
-        )
-        editMenu.addAction(insertSampleBackground)
-        copy_= QAction("Copy", editMenu)
+        if self.model():
+            insertSampleBackground = QAction(
+                "Insert Sample Background", editMenu
+            )
+            insertSampleBackground.triggered.connect(
+                self.insertSampleBackground
+            )
+            editMenu.addAction(insertSampleBackground)
+        copy_ = QAction("Copy", editMenu)
         copy_.triggered.connect(self.copy)
         cut = QAction("Cut", editMenu)
         cut.triggered.connect(self.cut)
         self.menu.addAction(copy_)
         self.menu.addAction(cut)
         if (
-            type(self.clipboard) == SampleBackground
+            isinstance(self.clipboard, SampleBackground)
             or
-            type(self.clipboard) == type(self.currentObject())
+            isinstance(self.clipboard, type(self.currentObject()))
             or
-            (type(self.clipboard) == Sample and type(self.currentObject()) == SampleBackground)
+            (
+                isinstance(self.clipboard, Sample)
+                and isinstance(self.currentObject(), SampleBackground)
+
+            )
             or
-            (type(self.clipboard) == Container and type(self.currentObject()) == Sample)
+            (
+                isinstance(self.clipboard, Container)
+                and isinstance(self.currentObject(), Sample)
+            )
         ):
             paste = QAction("Paste", editMenu)
             paste.triggered.connect(self.paste)
@@ -709,7 +720,7 @@ class GudPyTreeView(QTreeView):
                 self.insertSample
             )
             editMenu.addAction(insertSample)
-        elif isinstance(self.currentObject(), (Sample, Container)):
+        if isinstance(self.currentObject(), (Sample, Container)):
             insertContainer = QAction("Insert Container", editMenu)
             insertContainer.triggered.connect(
                 self.insertContainer

--- a/src/gui/widgets/gudpy_tree.py
+++ b/src/gui/widgets/gudpy_tree.py
@@ -713,12 +713,24 @@ class GudPyTreeView(QTreeView):
             paste = QAction("Paste", self.menu)
             paste.triggered.connect(self.paste)
             self.menu.addAction(paste)
-        if isinstance(self.currentObject(), (SampleBackground, Sample)):
+        if isinstance(self.currentObject(), (
+            SampleBackground, Sample, Container)
+        ):
             insertSample = QAction("Insert Sample", self.menu)
             insertSample.triggered.connect(
                 self.insertSample
             )
             self.menu.addAction(insertSample)
+            selectAllSamples = QAction("Select All Samples", self.menu)
+            selectAllSamples.triggered.connect(
+                self.selectAllSamples
+            )
+            self.menu.addAction(selectAllSamples)
+            deselectAllSamples = QAction("Deselect All Samples", self.menu)
+            deselectAllSamples.triggered.connect(
+                self.deselectAllSamples
+            )
+            self.menu.addAction(deselectAllSamples)
         if isinstance(self.currentObject(), (Sample, Container)):
             insertContainer = QAction("Insert Container", self.menu)
             insertContainer.triggered.connect(
@@ -804,3 +816,39 @@ class GudPyTreeView(QTreeView):
             self.insertSample(sample=deepcopy(self.clipboard))
         elif isinstance(self.clipboard, Container):
             self.insertContainer(container=deepcopy(self.clipboard))
+
+    def selectAllSamples(self):
+        if isinstance(self.currentObject(), (SampleBackground)):
+            for i in range(len(self.currentObject().samples)):
+                self.currentObject().samples[i].runThisSample = True
+        elif isinstance(self.currentObject(), Sample):
+            parent = self.model().findParent(self.currentObject())
+            for i in range(len(parent.samples)):
+                parent.samples[i].runThisSample = True
+        elif isinstance(self.currentObject(), Container):
+            grandparent = (
+                    self.model().findParent(
+                        self.model().findParent(
+                            self.currentObject())
+                    )
+            )
+            for i in range(len(grandparent.samples)):
+                grandparent.samples[i].runThisSample = True
+
+    def deselectAllSamples(self):
+        if isinstance(self.currentObject(), (SampleBackground)):
+            for i in range(len(self.currentObject().samples)):
+                self.currentObject().samples[i].runThisSample = False
+        elif isinstance(self.currentObject(), Sample):
+            parent = self.model().findParent(self.currentObject())
+            for i in range(len(parent.samples)):
+                parent.samples[i].runThisSample = False
+        elif isinstance(self.currentObject(), Container):
+            grandparent = (
+                    self.model().findParent(
+                        self.model().findParent(
+                            self.currentObject())
+                    )
+            )
+            for i in range(len(grandparent.samples)):
+                grandparent.samples[i].runThisSample = False

--- a/src/gui/widgets/gudpy_tree.py
+++ b/src/gui/widgets/gudpy_tree.py
@@ -762,6 +762,8 @@ class GudPyTreeView(QTreeView):
         # If the model has been instantiated,
         # allow insertion of sample backgrounds.
         if self.model():
+            if isinstance(self.currentObject(), (Sample, Container)):
+                insertSampleBackground.setText("Append Sample Background")
             insertSampleBackground.setEnabled(True)
         # If the model has been instantiated
         # and the current object type can have siblings

--- a/src/gui/widgets/gudpy_tree.py
+++ b/src/gui/widgets/gudpy_tree.py
@@ -570,6 +570,8 @@ class GudPyTreeView(QTreeView):
         Inserts an object into the current row in the model.
     removeRow()
         Removes the current index from the model.
+    contextMenuEvent(event)
+        Creates context menu, for right clicking the table.
     insertSampleBackground_(sampleBackground)
         Inserts a SampleBackground into the GudrunFile.
     insertSample_(sample)
@@ -582,6 +584,16 @@ class GudPyTreeView(QTreeView):
         Cuts the current object to the clipboard.
     paste_()
         Pastes the clipboard back into the GudrunFile.
+    duplicate()
+        Duplicates the current Sample.
+    duplicateOnlySample()
+        Duplicates the current Sample without any containers.
+    selectAllSamples()
+        Selects all samples belonging to a SampleBackground.
+    deselectAllSamples()
+        Deselects all samples belonging to a SampleBackground.
+    selectOnlyThisSample()
+        Selects only the current sample, and deselects all others.
     """
 
     def __init__(self, parent):
@@ -679,25 +691,95 @@ class GudPyTreeView(QTreeView):
         event : QMouseEvent
             The event that triggers the context menu.
         """
+        # Create the menu
         self.menu = QMenu(self)
-        if self.model():
-            insertSampleBackground = QAction(
-                "Insert Sample Background", self.menu
-            )
-            insertSampleBackground.triggered.connect(
-                self.insertSampleBackground
-            )
-            self.menu.addAction(insertSampleBackground)
+        # Actions for insertion
+        insertSampleBackground = QAction(
+            "Insert Sample Background", self.menu
+        )
+        insertSampleBackground.triggered.connect(
+            self.insertSampleBackground
+        )
+        insertSampleBackground.setDisabled(True)
+        self.menu.addAction(insertSampleBackground)
+        insertContainer = QAction("Insert Container", self.menu)
+        insertContainer.triggered.connect(
+            self.insertContainer
+        )
+        insertContainer.setDisabled(True)
+        self.menu.addAction(insertContainer)
+        insertSample = QAction("Insert Sample", self.menu)
+        insertSample.triggered.connect(
+            self.insertSample
+        )
+        insertSample.setDisabled(True)
+        self.menu.addAction(insertSample)
+
+        # Selection actions
+        selectAllSamples = QAction("Select All Samples", self.menu)
+        selectAllSamples.triggered.connect(
+            self.selectAllSamples
+        )
+        selectAllSamples.setDisabled(True)
+        self.menu.addAction(selectAllSamples)
+        deselectAllSamples = QAction("Deselect All Samples", self.menu)
+        deselectAllSamples.triggered.connect(
+            self.deselectAllSamples
+        )
+        deselectAllSamples.setDisabled(True)
+        self.menu.addAction(deselectAllSamples)
+        selectOnlyThisSample = QAction("Select Only This Sample", self.menu)
+        selectOnlyThisSample.triggered.connect(
+            self.selectOnlyThisSample
+        )
+        selectOnlyThisSample.setDisabled(True)
+        self.menu.addAction(selectOnlyThisSample)
+
+        # Copy/cut/paste actions
         copy_ = QAction("Copy", self.menu)
         copy_.triggered.connect(self.copy)
-        cut = QAction("Cut", )
-        cut.triggered.connect(self.cut)
+        copy_.setDisabled(True)
         self.menu.addAction(copy_)
+        cut = QAction("Cut", self.menu)
+        cut.triggered.connect(self.cut)
+        cut.setDisabled(True)
         self.menu.addAction(cut)
+        paste = QAction("Paste", self.menu)
+        paste.setDisabled(True)
+        paste.triggered.connect(self.paste)
+        self.menu.addAction(paste)
+
+        # Duplicate actions
+        duplicate = QAction("Duplicate Sample", self.menu)
+        duplicate.triggered.connect(self.duplicateSample)
+        duplicate.setDisabled(True)
+        self.menu.addAction(duplicate)
+        duplicateOnlySample = QAction("Duplicate Only Sample", self.menu)
+        duplicateOnlySample.triggered.connect(self.duplicateOnlySample)
+        duplicateOnlySample.setDisabled(True)
+        self.menu.addAction(duplicateOnlySample)
+
+        # If the model has been instantiated,
+        # allow insertion of sample backgrounds.
+        if self.model():
+            insertSampleBackground.setEnabled(True)
+        # If the model has been instantiated
+        # and the current object type can have siblings
+        if self.model() and isinstance(self.currentObject(), (
+            SampleBackground, Sample, Container)
+        ):
+            copy_.setEnabled(True)
+            cut.setEnabled(True)
+
+        # If the clipboard can be pasted under the current object.
+        # Sample backgrounds default to append if this is not the case.
         if (
             isinstance(self.clipboard, SampleBackground)
             or
-            isinstance(self.clipboard, type(self.currentObject()))
+            (
+                isinstance(self.clipboard, type(self.currentObject()))
+                and self.clipboard
+            )
             or
             (
                 isinstance(self.clipboard, Sample)
@@ -709,34 +791,28 @@ class GudPyTreeView(QTreeView):
                 isinstance(self.clipboard, Container)
                 and isinstance(self.currentObject(), Sample)
             )
+            and self.clipboard
         ):
-            paste = QAction("Paste", self.menu)
-            paste.triggered.connect(self.paste)
-            self.menu.addAction(paste)
+            paste.setEnabled(True)
+
+        # Enable selecting/deselecting all samples
         if isinstance(self.currentObject(), (
             SampleBackground, Sample, Container)
         ):
-            insertSample = QAction("Insert Sample", self.menu)
-            insertSample.triggered.connect(
-                self.insertSample
-            )
-            self.menu.addAction(insertSample)
-            selectAllSamples = QAction("Select All Samples", self.menu)
-            selectAllSamples.triggered.connect(
-                self.selectAllSamples
-            )
-            self.menu.addAction(selectAllSamples)
-            deselectAllSamples = QAction("Deselect All Samples", self.menu)
-            deselectAllSamples.triggered.connect(
-                self.deselectAllSamples
-            )
-            self.menu.addAction(deselectAllSamples)
+            selectAllSamples.setEnabled(True)
+            deselectAllSamples.setEnabled(True)
+
+        # Enable insertion of samples and containers.
+        if isinstance(self.currentObject(), (SampleBackground, Sample)):
+            insertSample.setEnabled(True)
         if isinstance(self.currentObject(), (Sample, Container)):
-            insertContainer = QAction("Insert Container", self.menu)
-            insertContainer.triggered.connect(
-                self.insertContainer
-            )
-            self.menu.addAction(insertContainer)
+            insertContainer.setEnabled(True)
+        # Enable duplication, and selection.
+        if isinstance(self.currentObject(), Sample):
+            duplicate.setEnabled(True)
+            duplicateOnlySample.setEnabled(True)
+            selectOnlyThisSample.setEnabled(True)
+        # Pop up the context menu.
         self.menu.popup(QCursor.pos())
 
     def insertSampleBackground(self, sampleBackground=None):
@@ -817,15 +893,36 @@ class GudPyTreeView(QTreeView):
         elif isinstance(self.clipboard, Container):
             self.insertContainer(container=deepcopy(self.clipboard))
 
+    def duplicateSample(self):
+        """
+        Duplicates the current Sample.
+        """
+        self.copy()
+        self.paste()
+
+    def duplicateOnlySample(self):
+        """
+        Duplicates the current Sample without any containers.
+        """
+        self.copy()
+        self.clipboard.containers = []
+        self.paste()
+
     def selectAllSamples(self):
+        """
+        Selects all samples belonging to a SampleBackground.
+        """
         if isinstance(self.currentObject(), (SampleBackground)):
+            # Select all children.
             for i in range(len(self.currentObject().samples)):
                 self.currentObject().samples[i].runThisSample = True
         elif isinstance(self.currentObject(), Sample):
+            # Select all siblings.
             parent = self.model().findParent(self.currentObject())
             for i in range(len(parent.samples)):
                 parent.samples[i].runThisSample = True
         elif isinstance(self.currentObject(), Container):
+            # Select parent and all it's siblings.
             grandparent = (
                     self.model().findParent(
                         self.model().findParent(
@@ -836,14 +933,20 @@ class GudPyTreeView(QTreeView):
                 grandparent.samples[i].runThisSample = True
 
     def deselectAllSamples(self):
+        """
+        Deselects all samples belonging to a SampleBackground.
+        """
         if isinstance(self.currentObject(), (SampleBackground)):
+            # Deselect all children.
             for i in range(len(self.currentObject().samples)):
                 self.currentObject().samples[i].runThisSample = False
         elif isinstance(self.currentObject(), Sample):
+            # Deselect all siblings.
             parent = self.model().findParent(self.currentObject())
             for i in range(len(parent.samples)):
                 parent.samples[i].runThisSample = False
         elif isinstance(self.currentObject(), Container):
+            # Deselect parent and all it's siblings.
             grandparent = (
                     self.model().findParent(
                         self.model().findParent(
@@ -852,3 +955,13 @@ class GudPyTreeView(QTreeView):
             )
             for i in range(len(grandparent.samples)):
                 grandparent.samples[i].runThisSample = False
+
+    def selectOnlyThisSample(self):
+        """
+        Selects only the current sample, and deselects all others.
+        """
+        self.deselectAllSamples()
+        if isinstance(self.currentObject(), Sample):
+            self.currentObject().runThisSample = True
+        if isinstance(self.currentObject(), Container):
+            self.model().findParent(self.currentObject()).runThisSample = True

--- a/src/gui/widgets/gudpy_tree.py
+++ b/src/gui/widgets/gudpy_tree.py
@@ -680,18 +680,17 @@ class GudPyTreeView(QTreeView):
             The event that triggers the context menu.
         """
         self.menu = QMenu(self)
-        editMenu = self.menu.addMenu("Edit")
         if self.model():
             insertSampleBackground = QAction(
-                "Insert Sample Background", editMenu
+                "Insert Sample Background", self.menu
             )
             insertSampleBackground.triggered.connect(
                 self.insertSampleBackground
             )
-            editMenu.addAction(insertSampleBackground)
-        copy_ = QAction("Copy", editMenu)
+            self.menu.addAction(insertSampleBackground)
+        copy_ = QAction("Copy", self.menu)
         copy_.triggered.connect(self.copy)
-        cut = QAction("Cut", editMenu)
+        cut = QAction("Cut", )
         cut.triggered.connect(self.cut)
         self.menu.addAction(copy_)
         self.menu.addAction(cut)
@@ -711,21 +710,21 @@ class GudPyTreeView(QTreeView):
                 and isinstance(self.currentObject(), Sample)
             )
         ):
-            paste = QAction("Paste", editMenu)
+            paste = QAction("Paste", self.menu)
             paste.triggered.connect(self.paste)
             self.menu.addAction(paste)
         if isinstance(self.currentObject(), (SampleBackground, Sample)):
-            insertSample = QAction("Insert Sample", editMenu)
+            insertSample = QAction("Insert Sample", self.menu)
             insertSample.triggered.connect(
                 self.insertSample
             )
-            editMenu.addAction(insertSample)
+            self.menu.addAction(insertSample)
         if isinstance(self.currentObject(), (Sample, Container)):
-            insertContainer = QAction("Insert Container", editMenu)
+            insertContainer = QAction("Insert Container", self.menu)
             insertContainer.triggered.connect(
                 self.insertContainer
             )
-            editMenu.addAction(insertContainer)
+            self.menu.addAction(insertContainer)
         self.menu.popup(QCursor.pos())
 
     def insertSampleBackground(self, sampleBackground=None):

--- a/src/gui/widgets/gudpy_tree.py
+++ b/src/gui/widgets/gudpy_tree.py
@@ -575,6 +575,12 @@ class GudPyTreeView(QTreeView):
         Inserts a Sample into the GudrunFile.
     insertContainer_(container)
         Inserts a Container into the GudrunFile.
+    copy_()
+        Copies the current object to the clipboard.
+    cut_()
+        Cuts the current object to the clipboard.
+    paste_()
+        Pastes the clipboard back into the GudrunFile.
     """
 
     def __init__(self, parent):

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -139,15 +139,15 @@ class GudPyMainWindow(QMainWindow):
             )
 
             self.insertSampleBackground.triggered.connect(
-                self.objectTree.insertSampleBackground_
+                self.objectTree.insertSampleBackground
             )
 
             self.insertSample.triggered.connect(
-                self.objectTree.insertSample_
+                self.objectTree.insertSample
             )
 
             self.insertContainer.triggered.connect(
-                self.objectTree.insertContainer_
+                self.objectTree.insertContainer
             )
 
             self.copy.triggered.connect(self.copy_)

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -52,14 +52,8 @@ class GudPyMainWindow(QMainWindow):
         Updates compositions across objects.
     updateComponents()
         Updates geometries and compositions.
-    copy_()
-        Copies the current object to the clipboard.
-    cut_()
-        Cuts the current object to the clipboard.
     del_()
         Deletes the current object.
-    paste_()
-        Pastes the clipboard back into the GudrunFile.
     exit_()
         Exits GudPy.
     """
@@ -150,10 +144,10 @@ class GudPyMainWindow(QMainWindow):
                 self.objectTree.insertContainer
             )
 
-            self.copy.triggered.connect(self.copy_)
-            self.cut.triggered.connect(self.cut_)
-            self.paste.triggered.connect(self.paste_)
-            self.delete_.triggered.connect(self.del_)
+            self.copy.triggered.connect(self.objectTree.copy)
+            self.cut.triggered.connect(self.objectTree.cut)
+            self.paste.triggered.connect(self.objectTree.paste)
+            self.delete_.triggered.connect(self.objectTree.del_)
 
         self.loadInputFile.triggered.connect(self.loadInputFile_)
         self.objectStack.currentChanged.connect(self.updateComponents)
@@ -225,43 +219,6 @@ class GudPyMainWindow(QMainWindow):
         """
         self.updateGeometries()
         self.updateCompositions()
-
-    def copy_(self):
-        """
-        Copies the current object to the clipboard.
-        """
-        self.clipboard = None
-        obj = self.objectTree.currentObject()
-        if isinstance(obj, (SampleBackground, Sample, Container)):
-            self.clipboard = deepcopy(obj)
-
-    def del_(self):
-        """
-        Deletes the current object.
-        """
-        self.objectTree.removeRow()
-
-    def cut_(self):
-        """
-        Copies the current object to the clipboard, and removes
-        the object from the tree.
-        """
-        self.copy_()
-        if self.clipboard:
-            self.objectTree.removeRow()
-
-    def paste_(self):
-        """
-        Pastes the contents of the clipboard back into the GudrunFile.
-        """
-        if isinstance(self.clipboard, SampleBackground):
-            self.objectTree.insertSampleBackground_(
-                sampleBackground=deepcopy(self.clipboard)
-            )
-        elif isinstance(self.clipboard, Sample):
-            self.objectTree.insertSample_(sample=deepcopy(self.clipboard))
-        elif isinstance(self.clipboard, Container):
-            self.objectTree.insertContainer_(container=deepcopy(self.clipboard))
 
     def exit_(self):
         """

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -1,7 +1,4 @@
 import sys
-from src.gudrun_classes.container import Container
-from src.gudrun_classes.sample import Sample
-from src.gudrun_classes.sample_background import SampleBackground
 from src.gudrun_classes.gudrun_file import GudrunFile, PurgeFile
 from src.gudrun_classes.exception import ParserException
 from src.gudrun_classes import config
@@ -20,7 +17,6 @@ from src.gui.widgets.normalisation_widget import NormalisationWidget
 from src.gudrun_classes.enums import Geometry
 import os
 from PyQt5 import uic
-from copy import deepcopy
 
 
 class GudPyMainWindow(QMainWindow):

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -52,12 +52,6 @@ class GudPyMainWindow(QMainWindow):
         Updates compositions across objects.
     updateComponents()
         Updates geometries and compositions.
-    insertSampleBackground_(sampleBackground)
-        Inserts a SampleBackground into the GudrunFile.
-    insertSample_(sample)
-        Inserts a Sample into the GudrunFile.
-    insertContainer_(container)
-        Inserts a Container into the GudrunFile.
     copy_()
         Copies the current object to the clipboard.
     cut_()
@@ -145,15 +139,15 @@ class GudPyMainWindow(QMainWindow):
             )
 
             self.insertSampleBackground.triggered.connect(
-                self.insertSampleBackground_
+                self.objectTree.insertSampleBackground_
             )
 
             self.insertSample.triggered.connect(
-                self.insertSample_
+                self.objectTree.insertSample_
             )
 
             self.insertContainer.triggered.connect(
-                self.insertContainer_
+                self.objectTree.insertContainer_
             )
 
             self.copy.triggered.connect(self.copy_)
@@ -232,47 +226,6 @@ class GudPyMainWindow(QMainWindow):
         self.updateGeometries()
         self.updateCompositions()
 
-    def insertSampleBackground_(self, sampleBackground=None):
-        """
-        Inserts a SampleBackground into the GudrunFile.
-        Inserts it into the tree.
-        Parameters
-        ----------
-        sampleBackground : SampleBackground, optional
-            SampleBackground object to insert.
-        """
-        if not sampleBackground:
-            sampleBackground = SampleBackground()
-        self.objectTree.insertRow(sampleBackground)
-
-    def insertSample_(self, sample=None):
-        """
-        Inserts a Sample into the GudrunFile.
-        Inserts it into the tree.
-        Parameters
-        ----------
-        sample : Sample, optional
-            Sample object to insert.
-        """
-        if not sample:
-            sample = Sample()
-            sample.name = "SAMPLE"  # for now, give a default name.
-        self.objectTree.insertRow(sample)
-
-    def insertContainer_(self, container=None):
-        """
-        Inserts a Container into the GudrunFile.
-        Inserts it into the tree.
-        Parameters
-        ----------
-        container : Container, optional
-            Container object to insert.
-        """
-        if not container:
-            container = Container()
-            container.name = "CONTAINER"  # for now, give a default name.
-        self.objectTree.insertRow(container)
-
     def copy_(self):
         """
         Copies the current object to the clipboard.
@@ -302,13 +255,13 @@ class GudPyMainWindow(QMainWindow):
         Pastes the contents of the clipboard back into the GudrunFile.
         """
         if isinstance(self.clipboard, SampleBackground):
-            self.insertSampleBackground_(
+            self.objectTree.insertSampleBackground_(
                 sampleBackground=deepcopy(self.clipboard)
             )
         elif isinstance(self.clipboard, Sample):
-            self.insertSample_(sample=deepcopy(self.clipboard))
+            self.objectTree.insertSample_(sample=deepcopy(self.clipboard))
         elif isinstance(self.clipboard, Container):
-            self.insertContainer_(container=deepcopy(self.clipboard))
+            self.objectTree.insertContainer_(container=deepcopy(self.clipboard))
 
     def exit_(self):
         """


### PR DESCRIPTION
A context menu has been added so that when right clicking in the tree, a menu appears.
This menu offers the following functionality:
- Copy
- Cut
- Paste
- Insert
- Select All
- Deselect All
- Select only this sample
- Duplicate sample
- Duplicate sample without containers.

Each action is added in context, so depending on the context of the current index selected, different actions are offered.

Closes #89.