### PR TITLE
Autoselect Instrument by default

### DIFF
--- a/src/gui/widgets/gudpy_tree.py
+++ b/src/gui/widgets/gudpy_tree.py
@@ -621,7 +621,7 @@ class GudPyTreeView(QTreeView):
         self.gudrunFile = gudrunFile
         self.sibling = sibling
         self.makeModel()
-        self.setCurrentIndex(self.model().index(0,0))
+        self.setCurrentIndex(self.model().index(0, 0))
         self.setHeaderHidden(True)
         self.clicked.connect(self.click)
 

--- a/src/gui/widgets/gudpy_tree.py
+++ b/src/gui/widgets/gudpy_tree.py
@@ -621,6 +621,7 @@ class GudPyTreeView(QTreeView):
         self.gudrunFile = gudrunFile
         self.sibling = sibling
         self.makeModel()
+        self.setCurrentIndex(self.model().index(0,0))
         self.setHeaderHidden(True)
         self.clicked.connect(self.click)
 


### PR DESCRIPTION
Very simple PR to force auto-selection of the `Instrument` in the `GudPyTreeView`, by default - to reflect the state of the `QStackedWidget` - which by default shows the `Instrument` tab. Closes #105.