### PR TITLE
Fix browsing files

### DIFF
--- a/src/gudrun_classes/data_files.py
+++ b/src/gudrun_classes/data_files.py
@@ -26,10 +26,6 @@ class DataFiles:
         """
         self.dataFiles = dataFiles
         self.name = name
-        self.str = [
-            df + "        " + name + " data files"
-            for df in dataFiles
-            ]
 
     def __str__(self):
         """
@@ -44,6 +40,10 @@ class DataFiles:
         string : str
             String representation of DataFiles.
         """
+        self.str = [
+            df + "        " + self.name + " data files"
+            for df in self.dataFiles
+            ]
         return """\n""".join(self.str)
 
     def __len__(self):

--- a/src/gudrun_classes/sample.py
+++ b/src/gudrun_classes/sample.py
@@ -240,7 +240,7 @@ class Sample:
 
         if self.outputUnits == OutputUnits.BARNS_ATOM_SR:
             outputUnits = "b/atom/sr"
-        elif self.outputUnits == OutputUnits.CM_INV_SR:
+        elif self.outputUnits == OutputUnits.INV_CM_SR:
             outputUnits = "cm**-1"
 
         unitsLine = (

--- a/src/gui/widgets/beam_widget.py
+++ b/src/gui/widgets/beam_widget.py
@@ -305,7 +305,8 @@ class BeamWidget(QWidget):
         Alters the corresponding line edit as such.
         as such.
         """
-        filename = QFileDialog.getOpenFileName(self, "Incident beam spectrum parameters", "")[0]
+        filename = QFileDialog.getOpenFileName(
+            self, "Incident beam spectrum parameters", "")[0]
         if filename:
             self.incidentBeamSpectrumParametersLineEdit.setText(filename)
 

--- a/src/gui/widgets/beam_widget.py
+++ b/src/gui/widgets/beam_widget.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QWidget
+from PyQt5.QtWidgets import QFileDialog, QWidget
 from PyQt5 import uic
 import os
 from src.gudrun_classes.enums import Geometry
@@ -50,6 +50,8 @@ class BeamWidget(QWidget):
     handleIncidentBeamSpectrumParamsFileChanged(value)
         Slot for handling change in the file
         for incident beam spectrum parameters.
+    handleBrowseIncidentBeamSpectrumParams()
+        Slot for browsing for an incident beam spectrum parameters file.
     handleOverallBackgroundFactorChanged(value)
         Slot for handling change in the overall background factor.
     handleSampleDependantBackgroundFactorChanged(value)
@@ -295,6 +297,18 @@ class BeamWidget(QWidget):
         if not self.widgetsRefreshing:
             self.parent.setModified()
 
+    def handleBrowseIncidentBeamSpectrumParams(self):
+        """
+        Slot for browsing for an incident beam spectrum parameters file.
+        Called when a clicked signal is emitted,
+        from the browseIncidentBeamSpectrumParametersButton.
+        Alters the corresponding line edit as such.
+        as such.
+        """
+        filename = QFileDialog.getOpenFileName(self, "Incident beam spectrum parameters", "")[0]
+        if filename:
+            self.incidentBeamSpectrumParametersLineEdit.setText(filename)
+
     def handleOverallBackgroundFactorChanged(self, value):
         """
         Slot for handling change in overall background factor.
@@ -454,6 +468,9 @@ class BeamWidget(QWidget):
         )
         self.incidentBeamSpectrumParametersLineEdit.textChanged.connect(
             self.handleIncidentBeamSpectrumParamsFileChanged
+        )
+        self.browseIncidentBeamSpectrumParametersButton.clicked.connect(
+            self.handleBrowseIncidentBeamSpectrumParams
         )
 
         # Setup widgets and slots, for Scattered beam.

--- a/src/gui/widgets/beam_widget.py
+++ b/src/gui/widgets/beam_widget.py
@@ -305,8 +305,8 @@ class BeamWidget(QWidget):
         Alters the corresponding line edit as such.
         as such.
         """
-        filename = QFileDialog.getOpenFileName(
-            self, "Incident beam spectrum parameters", "")[0]
+        filename, _ = QFileDialog.getOpenFileName(
+            self, "Incident beam spectrum parameters", "")
         if filename:
             self.incidentBeamSpectrumParametersLineEdit.setText(filename)
 

--- a/src/gui/widgets/container_widget.py
+++ b/src/gui/widgets/container_widget.py
@@ -510,7 +510,7 @@ class ContainerWidget(QWidget):
         # Populate cross section source combo box.
         for c in CrossSectionSource:
             self.totalCrossSectionComboBox.addItem(c.name, c)
-    
+
         self.totalCrossSectionComboBox.currentIndexChanged.connect(
             self.handleTotalCrossSectionChanged
         )
@@ -555,7 +555,6 @@ class ContainerWidget(QWidget):
 
         self.angleOfRotationSpinBox.setValue(self.container.angleOfRotation)
         self.sampleWidthSpinBox.setValue(self.container.sampleWidth)
-
 
         # Cylindrical
         self.innerRadiiSpinBox.setValue(self.container.innerRadius)

--- a/src/gui/widgets/container_widget.py
+++ b/src/gui/widgets/container_widget.py
@@ -385,11 +385,13 @@ class ContainerWidget(QWidget):
         regex : str
             Regex-like expression to use for specifying file types.
         """
-        paths = QFileDialog.getOpenFileNames(self, title, ".", regex)
-        for path in paths:
-            if path:
-                target.addItem(path)
+        files = QFileDialog.getOpenFileNames(self, title, ".", regex)[0]
+        for file in files:
+            if file:
+                target.addItem(file.split("/")[-1])
                 self.handleDataFileInserted(target.item(target.count() - 1))
+        if not self.widgetsRefreshing:
+            self.parent.setModified()
 
     def removeFile(self, target, dataFiles):
         """

--- a/src/gui/widgets/container_widget.py
+++ b/src/gui/widgets/container_widget.py
@@ -408,7 +408,6 @@ class ContainerWidget(QWidget):
         if target.currentIndex().isValid():
             remove = target.takeItem(target.currentRow()).text()
             dataFiles.dataFiles.remove(remove)
-            self.updateDataFilesList()
             if not self.widgetsRefreshing:
                 self.parent.setModified()
 

--- a/src/gui/widgets/container_widget.py
+++ b/src/gui/widgets/container_widget.py
@@ -83,6 +83,7 @@ class ContainerWidget(QWidget):
 
         super(ContainerWidget, self).__init__(parent=self.parent)
         self.loadUI()
+        self.setupUI()
 
     def loadUI(self):
         """
@@ -439,19 +440,11 @@ class ContainerWidget(QWidget):
         if not self.widgetsRefreshing:
             self.parent.setModified()
 
-    def initComponents(self):
-        """
-        Populates the child widgets with their
-        corresponding data from the attributes of the Container object.
-        """
-        # Acquire the lock
-        self.widgetsRefreshing = True
-        # Setup widget and slot for the period number.
-        self.periodNoSpinBox.setValue(self.container.periodNumber)
+    def setupUI(self):
+        # Setup slot for period number.
         self.periodNoSpinBox.valueChanged.connect(self.handlePeriodNoChanged)
 
-        # Setup widgets and slots for the data files.
-        self.updateDataFilesList()
+        # Setup slots for data files.
         self.dataFilesList.itemChanged.connect(self.handleDataFilesAltered)
         self.dataFilesList.itemEntered.connect(self.handleDataFileInserted)
         self.addDataFileButton.clicked.connect(
@@ -468,99 +461,130 @@ class ContainerWidget(QWidget):
             )
         )
 
-        # Setup widgets and slots for geometry.
+        # Populate geometry combo box.
         for g in Geometry:
-            if self.geometryComboBox.findText(g.name) == -1:
-                self.geometryComboBox.addItem(g.name, g)
-        self.geometryComboBox.setCurrentIndex(self.container.geometry.value)
+            self.geometryComboBox.addItem(g.name, g)
+
+        # Setup slots for geometry data.
         self.geometryComboBox.currentIndexChanged.connect(
             self.handleGeometryChanged
         )
-
         self.geometryComboBox.setDisabled(True)
 
-        # Ensure the correct attributes are being
-        # shown for the correct geometry.
-        self.geometryInfoStack.setCurrentIndex(config.geometry.value)
-
-        # Setup the widgets and slots for geometry specific attributes.
         # Flatplate
-        self.upstreamSpinBox.setValue(self.container.upstreamThickness)
         self.upstreamSpinBox.valueChanged.connect(
             self.handleUpstreamThicknessChanged
         )
-        self.downstreamSpinBox.setValue(self.container.downstreamThickness)
         self.downstreamSpinBox.valueChanged.connect(
             self.handleDownstreamThicknessChanged
         )
 
-        self.angleOfRotationSpinBox.setValue(self.container.angleOfRotation)
         self.angleOfRotationSpinBox.valueChanged.connect(
             self.handleAngleOfRotationChanged
         )
-        self.sampleWidthSpinBox.setValue(self.container.sampleWidth)
         self.sampleWidthSpinBox.valueChanged.connect(
             self.handleSampleWidthChanged
         )
 
         # Cylindrical
-        self.innerRadiiSpinBox.setValue(self.container.innerRadius)
         self.innerRadiiSpinBox.valueChanged.connect(
             self.handleInnerRadiiChanged
         )
-        self.outerRadiiSpinBox.setValue(self.container.outerRadius)
         self.outerRadiiSpinBox.valueChanged.connect(
             self.handleOuterRadiiChanged
         )
 
-        self.sampleHeightSpinBox.setValue(self.container.sampleHeight)
         self.sampleHeightSpinBox.valueChanged.connect(
             self.handleSampleHeightChanged
         )
 
-        # Setup the widgets and slots for the density.
-        self.densitySpinBox.setValue(self.container.density)
+        # Setup slots for density data.
         self.densitySpinBox.valueChanged.connect(self.handleDensityChanged)
 
+        # Populate density units combo box.
         for du in UnitsOfDensity:
-            if self.densityUnitsComboBox.findText(du.name) == -1:
-                self.densityUnitsComboBox.addItem(du.name, du)
-        self.densityUnitsComboBox.setCurrentIndex(
-            self.container.densityUnits.value
-        )
+            self.densityUnitsComboBox.addItem(du.name, du)
 
-        # Setup the other container configurations widgets and slots.
+        # Setup slots for other container configuration data.
+        # Populate cross section source combo box.
         for c in CrossSectionSource:
-            if self.totalCrossSectionComboBox.findText(c.name) == -1:
-                self.totalCrossSectionComboBox.addItem(c.name, c)
-        self.totalCrossSectionComboBox.setCurrentIndex(
-            self.container.totalCrossSectionSource.value
-        )
+            self.totalCrossSectionComboBox.addItem(c.name, c)
+    
         self.totalCrossSectionComboBox.currentIndexChanged.connect(
             self.handleTotalCrossSectionChanged
         )
-
-        self.tweakFactorSpinBox.setValue(self.container.tweakFactor)
         self.tweakFactorSpinBox.valueChanged.connect(
             self.handleTweakFactorChanged
         )
-
-        self.scatteringFractionSpinBox.setValue(
-            self.container.scatteringFraction
-        )
         self.scatteringFractionSpinBox.valueChanged.connect(
             self.handleScatteringFractionChanged
-        )
-        self.attenuationCoefficientSpinBox.setValue(
-            self.container.attenuationCoefficient
         )
         self.attenuationCoefficientSpinBox.valueChanged.connect(
             self.handleAttenuationCoefficientChanged
         )
 
-        # Setup the widgets and slots for the composition.
-        self.updateCompositionTable()
+        # Setup slots for composition table.
         self.insertElementButton.clicked.connect(self.handleInsertElement)
         self.removeElementButton.clicked.connect(self.handleRemoveElement)
+
+    def initComponents(self):
+        """
+        Populates the child widgets with their
+        corresponding data from the attributes of the Container object.
+        """
+        # Acquire the lock
+        self.widgetsRefreshing = True
+        # Populate the period number.
+        self.periodNoSpinBox.setValue(self.container.periodNumber)
+
+        # Populate data files.
+        self.updateDataFilesList()
+
+        # Populate geometry data.
+        self.geometryComboBox.setCurrentIndex(self.container.geometry.value)
+
+        # Ensure the correct attributes are being
+        # shown for the correct geometry.
+        self.geometryInfoStack.setCurrentIndex(config.geometry.value)
+
+        # Populate geometry specific attributes.
+        # Flatplate
+        self.upstreamSpinBox.setValue(self.container.upstreamThickness)
+        self.downstreamSpinBox.setValue(self.container.downstreamThickness)
+
+        self.angleOfRotationSpinBox.setValue(self.container.angleOfRotation)
+        self.sampleWidthSpinBox.setValue(self.container.sampleWidth)
+
+
+        # Cylindrical
+        self.innerRadiiSpinBox.setValue(self.container.innerRadius)
+        self.outerRadiiSpinBox.setValue(self.container.outerRadius)
+
+        self.sampleHeightSpinBox.setValue(self.container.sampleHeight)
+
+        # Populate density data.
+        self.densitySpinBox.setValue(self.container.density)
+        self.densityUnitsComboBox.setCurrentIndex(
+            self.container.densityUnits.value
+        )
+
+        # Populate other container configuration data.
+        self.totalCrossSectionComboBox.setCurrentIndex(
+            self.container.totalCrossSectionSource.value
+        )
+
+        self.tweakFactorSpinBox.setValue(self.container.tweakFactor)
+
+        self.scatteringFractionSpinBox.setValue(
+            self.container.scatteringFraction
+        )
+
+        self.attenuationCoefficientSpinBox.setValue(
+            self.container.attenuationCoefficient
+        )
+
+        # Populate composition table.
+        self.updateCompositionTable()
+
         # Release the lock
         self.widgetsRefreshing = False

--- a/src/gui/widgets/container_widget.py
+++ b/src/gui/widgets/container_widget.py
@@ -385,7 +385,7 @@ class ContainerWidget(QWidget):
         regex : str
             Regex-like expression to use for specifying file types.
         """
-        files = QFileDialog.getOpenFileNames(self, title, ".", regex)[0]
+        files, _ = QFileDialog.getOpenFileNames(self, title, ".", regex)
         for file in files:
             if file:
                 target.addItem(file.split("/")[-1])

--- a/src/gui/widgets/instrument_widget.py
+++ b/src/gui/widgets/instrument_widget.py
@@ -640,7 +640,7 @@ class InstrumentWidget(QWidget):
         """
         filename = self.browseFile(title, dir=dir)
         if filename:
-            target.setText(filename[0])
+            target.setText(filename)
 
     def browseFile(self, title, dir=False):
         """
@@ -656,7 +656,7 @@ class InstrumentWidget(QWidget):
         str[]
         """
         filename = (
-            QFileDialog.getOpenFileName(self, title, "")
+            QFileDialog.getOpenFileName(self, title, "")[0]
             if not dir
             else QFileDialog.getExistingDirectory(self, title, "")
         )

--- a/src/gui/widgets/instrument_widget.py
+++ b/src/gui/widgets/instrument_widget.py
@@ -750,7 +750,11 @@ class InstrumentWidget(QWidget):
         self.groupsFileLineEdit.textChanged.connect(
             self.handleGroupsFileChanged
         )
-
+        self.browseGroupsFileButton.clicked.connect(
+            lambda: self.handleBrowse(
+                self.groupsFileLineEdit, "Groups file"
+            )
+        )
         self.deadtimeFileLineEdit.setText(
             self.instrument.deadtimeConstantsFileName
         )

--- a/src/gui/widgets/instrument_widget.py
+++ b/src/gui/widgets/instrument_widget.py
@@ -655,11 +655,10 @@ class InstrumentWidget(QWidget):
         -------
         str[]
         """
-        filename = (
-            QFileDialog.getOpenFileName(self, title, "")[0]
-            if not dir
-            else QFileDialog.getExistingDirectory(self, title, "")
-        )
+        if dir:
+            filename = QFileDialog.getExistingDirectory(self, title, "")
+        else:
+            filename, _ = QFileDialog.getOpenFileName(self, title, "")
         return filename
 
     def updateGroupingParameterPanel(self):

--- a/src/gui/widgets/sample_background_widget.py
+++ b/src/gui/widgets/sample_background_widget.py
@@ -131,7 +131,7 @@ class SampleBackgroundWidget(QWidget):
         )
 
     def addFiles(self, target, title, regex):
-        files = QFileDialog.getOpenFileNames(self, title, ".", regex)[0]
+        files, _ = QFileDialog.getOpenFileNames(self, title, ".", regex)
         for file in files:
             if file:
                 target.addItem(file.split("/")[-1])

--- a/src/gui/widgets/sample_background_widget.py
+++ b/src/gui/widgets/sample_background_widget.py
@@ -21,6 +21,8 @@ class SampleBackgroundWidget(QWidget):
         Gives the focus of the SampleBackgroundWidget to the sample.
     loadUI()
         Loads the UI file for the SampleBackgroundWidget object.
+    setupUI()
+        Setup slots, signals and widgets.
     initComponents()
         Loads UI file, and then populates data from the SampleBackground.
     """
@@ -37,6 +39,7 @@ class SampleBackgroundWidget(QWidget):
         self.parent = parent
         super(SampleBackgroundWidget, self).__init__(parent=self.parent)
         self.loadUI()
+        self.setupUI()
 
     def setSampleBackground(self, sampleBackground):
         """
@@ -62,13 +65,15 @@ class SampleBackgroundWidget(QWidget):
         )
         uic.loadUi(uifile, self)
 
-    def initComponents(self):
+    def setupUI(self):
         """
-        Populates the child widgets with their
-        corresponding data from the attributes of the SampleBackground object.
+        Setup slots, signals and widgets.
         """
-        # Setup widgets and slots for the data files.
-        self.updateDataFilesList()
+
+        # Setup slot for period number.
+        self.periodNoSpinBox.valueChanged.connect(self.handlePeriodNoChanged)
+
+        # Setup slots for data files.
         self.dataFilesList.itemChanged.connect(self.handleDataFilesAltered)
         self.dataFilesList.itemEntered.connect(self.handleDataFileInserted)
         self.addDataFileButton.clicked.connect(
@@ -85,9 +90,19 @@ class SampleBackgroundWidget(QWidget):
             )
         )
 
-        # Setup widgets and slots for the period number.
+    def initComponents(self):
+        """
+        Populates the child widgets with their
+        corresponding data from the attributes of the SampleBackground object.
+        """
+        # Acquire the lock
+        self.widgetsRefreshing = True
+
+        # Populate period number.
         self.periodNoSpinBox.setValue(self.sampleBackground.periodNumber)
-        self.periodNoSpinBox.valueChanged.connect(self.handlePeriodNoChanged)
+
+        # Populate data files list.
+        self.updateDataFilesList()
 
         # Release the lock
         self.widgetsRefreshing = False
@@ -116,17 +131,18 @@ class SampleBackgroundWidget(QWidget):
         )
 
     def addFiles(self, target, title, regex):
-        paths = QFileDialog.getOpenFileNames(self, title, ".", regex)
-        for path in paths:
-            if path:
-                target.addItem(path)
+        files = QFileDialog.getOpenFileNames(self, title, ".", regex)[0]
+        for file in files:
+            if file:
+                target.addItem(file.split("/")[-1])
                 self.handleDataFileInserted(target.item(target.count() - 1))
+        if not self.widgetsRefreshing:
+            self.parent.setModified()
 
     def removeFile(self, target, dataFiles):
         if target.currentIndex().isValid():
             remove = target.takeItem(target.currentRow()).text()
             dataFiles.dataFiles.remove(remove)
-            self.updateDataFilesList()
             if not self.widgetsRefreshing:
                 self.parent.setModified()
 

--- a/src/gui/widgets/sample_widget.py
+++ b/src/gui/widgets/sample_widget.py
@@ -798,6 +798,11 @@ class SampleWidget(QWidget):
         self.normaliseToComboBox.currentIndexChanged.connect(
             self.handleNormaliseToChanged
         )
+
+        # Fill the output units combo box.
+        for u in OutputUnits:
+            self.outputUnitsComboBox.addItem(u.name, u)
+
         self.outputUnitsComboBox.currentIndexChanged.connect(
             self.handleOutputUnitsChanged
         )
@@ -913,10 +918,6 @@ class SampleWidget(QWidget):
 
         self.normaliseToComboBox.setCurrentIndex(self.sample.normaliseTo.value)
 
-
-        for u in OutputUnits:
-            if self.outputUnitsComboBox.findText(u.name) == -1:
-                self.outputUnitsComboBox.addItem(u.name, u)
         self.outputUnitsComboBox.setCurrentIndex(self.sample.outputUnits.value)
 
 
@@ -930,9 +931,7 @@ class SampleWidget(QWidget):
         self.maxSpinBox.setValue(self.sample.maxRadFT)
 
         self.broadeningFunctionSpinBox.setValue(self.sample.grBroadening)
-
         self.broadeningPowerSpinBox.setValue(self.sample.powerForBroadening)
-
         self.stepSizeSpinBox.setValue(self.sample.stepSize)
 
         # Populate advanced attributes.

--- a/src/gui/widgets/sample_widget.py
+++ b/src/gui/widgets/sample_widget.py
@@ -624,7 +624,6 @@ class SampleWidget(QWidget):
         if target.currentIndex().isValid():
             remove = target.takeItem(target.currentRow()).text()
             dataFiles.dataFiles.remove(remove)
-            self.updateDataFilesList()
             if not self.widgetsRefreshing:
                 self.parent.setModified()
 

--- a/src/gui/widgets/sample_widget.py
+++ b/src/gui/widgets/sample_widget.py
@@ -602,7 +602,7 @@ class SampleWidget(QWidget):
         regex : str
             Regex-like expression to use for specifying file types.
         """
-        files = QFileDialog.getOpenFileNames(self, title, ".", regex)[0]
+        files, _ = QFileDialog.getOpenFileNames(self, title, ".", regex)
         for file in files:
             if file:
                 target.addItem(file.split("/")[-1])

--- a/src/gui/widgets/sample_widget.py
+++ b/src/gui/widgets/sample_widget.py
@@ -892,7 +892,7 @@ class SampleWidget(QWidget):
         self.geometryInfoStack.setCurrentIndex(config.geometry.value)
         self.geometryInfoStack_.setCurrentIndex(config.geometry.value)
 
-        # Setup the widgets and slots for geometry specific attributes.
+        # Populate geometry specific attributes.
         # Flatplate
         self.upstreamSpinBox.setValue(self.sample.upstreamThickness)
         self.downstreamSpinBox.setValue(self.sample.downstreamThickness)

--- a/src/gui/widgets/sample_widget.py
+++ b/src/gui/widgets/sample_widget.py
@@ -30,6 +30,8 @@ class SampleWidget(QWidget):
         Loads the UI file for the SampleWidget object.
     setSample(sample)
         Gives the focus of the SampleWidget to the sample.
+    connectSlots()
+        Connect the slots to the signals.
     initComponents()
         Loads UI file, and then populates data from the Sample.
     handlePeriodNoChanged(value)

--- a/src/gui/widgets/sample_widget.py
+++ b/src/gui/widgets/sample_widget.py
@@ -30,8 +30,8 @@ class SampleWidget(QWidget):
         Loads the UI file for the SampleWidget object.
     setSample(sample)
         Gives the focus of the SampleWidget to the sample.
-    connectSlots()
-        Connect the slots to the signals.
+    setupUI()
+        Setup slots, signals and widgets.
     initComponents()
         Loads UI file, and then populates data from the Sample.
     handlePeriodNoChanged(value)
@@ -127,7 +127,7 @@ class SampleWidget(QWidget):
         self.parent = parent
         super(SampleWidget, self).__init__(parent=self.parent)
         self.loadUI()
-        self.connectSlots()
+        self.setupUI()
     def setSample(self, sample):
         """
         Gives the focus of the SampleWidget to the sample.
@@ -712,9 +712,9 @@ class SampleWidget(QWidget):
         if not self.widgetsRefreshing:
             self.parent.setModified()
 
-    def connectSlots(self):
+    def setupUI(self):
         """
-        Connect the slots to the signals.
+        Setup slots, signals and widgets.
         """
 
         # Setup slot for period number.

--- a/src/gui/widgets/sample_widget.py
+++ b/src/gui/widgets/sample_widget.py
@@ -128,6 +128,7 @@ class SampleWidget(QWidget):
         super(SampleWidget, self).__init__(parent=self.parent)
         self.loadUI()
         self.setupUI()
+
     def setSample(self, sample):
         """
         Gives the focus of the SampleWidget to the sample.
@@ -787,7 +788,7 @@ class SampleWidget(QWidget):
         # Fill the cross section source combo box.
         for c in CrossSectionSource:
             self.totalCrossSectionComboBox.addItem(c.name, c)
-    
+
         self.totalCrossSectionComboBox.currentIndexChanged.connect(
             self.handleCrossSectionSourceChanged
         )
@@ -920,7 +921,6 @@ class SampleWidget(QWidget):
         self.normaliseToComboBox.setCurrentIndex(self.sample.normaliseTo.value)
 
         self.outputUnitsComboBox.setCurrentIndex(self.sample.outputUnits.value)
-
 
         # Populate the tweak factor.
         self.tweakFactorSpinBox.setValue(self.sample.sampleTweakFactor)


### PR DESCRIPTION
Fairly simple PR, fixing up some bugs identified in #108.
Main feature is that across `SampleBackgroundWidgets`, `SampleWidgets` and `ContainerWidgets`, slots are connected to the signals from the widgets in their own method, `setupUI()`, instead of being connected inside `initComponents()` - which caused multiple slots to be connected, where only one should have been.
Also fixed bugs with the `__str__` methods of `DataFiles` and `Sample`.

Closes #108, as mentioned above.