### PR TITLE
Toggle grouping parameter panel

### DIFF
--- a/src/gui/widgets/instrument_widget.py
+++ b/src/gui/widgets/instrument_widget.py
@@ -99,6 +99,8 @@ class InstrumentWidget(QWidget):
         Slot for handling adding a row to the grouping parameter panel.
     handleRemoveGroupingParameter()
         Slot for removing a row from the grouping parameter panel.
+    handleGroupingParameterPanelToggled()
+        Slot for handling toggling the grouping parameter panel.
     """
 
     def __init__(self, instrument, parent=None):
@@ -693,6 +695,14 @@ class InstrumentWidget(QWidget):
         if not self.widgetsRefreshing:
             self.parent.setModified()
 
+    def handleGroupingParameterPanelToggled(self, on):
+        """
+        Slot for handling toggling the grouping parameter panel.
+        Called when a toggled signal is emitted from the
+        groupingParameterGroupBox.
+        """
+        self.groupingParameterWidget.setVisible(on)
+
     def initComponents(self):
         """
         Loads the UI file for the InstrumentWidget object,
@@ -1026,6 +1036,10 @@ class InstrumentWidget(QWidget):
         )
         self.removeGroupingParameterButton.clicked.connect(
             self.handleRemoveGroupingParameter
+        )
+        self.groupingParameterGroupBox.setChecked(False)
+        self.groupingParameterGroupBox.toggled.connect(
+            self.handleGroupingParameterPanelToggled
         )
         # Release the lock
         self.widgetsRefreshing = False

--- a/src/gui/widgets/ui_files/instrumentWidget.ui
+++ b/src/gui/widgets/ui_files/instrumentWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>724</width>
-    <height>912</height>
+    <height>1071</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -30,14 +30,14 @@
      </property>
      <property name="minimumSize">
       <size>
-       <width>640</width>
-       <height>91</height>
+       <width>0</width>
+       <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>561</width>
-       <height>91</height>
+       <width>16777215</width>
+       <height>16777215</height>
       </size>
      </property>
      <property name="title">
@@ -57,32 +57,6 @@
         </property>
         <property name="text">
          <string>Instrument Name</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="nameComboBox">
-        <property name="minimumSize">
-         <size>
-          <width>104</width>
-          <height>26</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>171</width>
-          <height>26</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QLineEdit" name="configLineEdit">
-        <property name="minimumSize">
-         <size>
-          <width>125</width>
-          <height>21</height>
-         </size>
         </property>
        </widget>
       </item>
@@ -109,6 +83,32 @@
         </property>
         <property name="text">
          <string>Instrument Config</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="configLineEdit">
+        <property name="minimumSize">
+         <size>
+          <width>125</width>
+          <height>21</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="nameComboBox">
+        <property name="minimumSize">
+         <size>
+          <width>104</width>
+          <height>26</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>171</width>
+          <height>26</height>
+         </size>
         </property>
        </widget>
       </item>
@@ -156,7 +156,7 @@
         <property name="title">
          <string>Spectrum Numbers for Beam Monitors</string>
         </property>
-        <widget class="QWidget" name="">
+        <widget class="QWidget" name="layoutWidget">
          <property name="geometry">
           <rect>
            <x>15</x>
@@ -1132,9 +1132,9 @@
            </layout>
           </item>
           <item>
-           <widget class="QGroupBox" name="groupBox">
+           <widget class="QGroupBox" name="groupingParameterGroupBox">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+             <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -1148,81 +1148,81 @@
             <property name="checkable">
              <bool>true</bool>
             </property>
-            <layout class="QGridLayout" name="gridLayout_3">
-             <item row="0" column="0">
+            <layout class="QVBoxLayout" name="verticalLayout_7">
+             <item>
               <widget class="QWidget" name="groupingParameterWidget" native="true">
                <property name="enabled">
                 <bool>true</bool>
                </property>
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+                <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
                </property>
-               <widget class="GroupingParameterTable" name="groupingParameterTable">
-                <property name="geometry">
-                 <rect>
-                  <x>12</x>
-                  <y>4</y>
-                  <width>270</width>
-                  <height>121</height>
-                 </rect>
+               <layout class="QHBoxLayout" name="horizontalLayout_19">
+                <property name="leftMargin">
+                 <number>0</number>
                 </property>
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
+                <property name="topMargin">
+                 <number>0</number>
                 </property>
-                <property name="minimumSize">
-                 <size>
-                  <width>270</width>
-                  <height>113</height>
-                 </size>
+                <property name="rightMargin">
+                 <number>25</number>
                 </property>
-                <property name="selectionBehavior">
-                 <enum>QAbstractItemView::SelectRows</enum>
-                </property>
-               </widget>
-               <widget class="QWidget" name="layoutWidget">
-                <property name="geometry">
-                 <rect>
-                  <x>292</x>
-                  <y>12</y>
-                  <width>32</width>
-                  <height>66</height>
-                 </rect>
-                </property>
-                <layout class="QVBoxLayout" name="verticalLayout">
-                 <item>
-                  <widget class="QPushButton" name="addGroupingParameterButton">
-                   <property name="maximumSize">
-                    <size>
-                     <width>30</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="text">
-                    <string>+</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="removeGroupingParameterButton">
-                   <property name="maximumSize">
-                    <size>
-                     <width>30</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="text">
-                    <string>-</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </widget>
+                <item>
+                 <widget class="GroupingParameterTable" name="groupingParameterTable">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="selectionBehavior">
+                   <enum>QAbstractItemView::SelectRows</enum>
+                  </property>
+                  <attribute name="horizontalHeaderMinimumSectionSize">
+                   <number>0</number>
+                  </attribute>
+                 </widget>
+                </item>
+                <item>
+                 <layout class="QVBoxLayout" name="verticalLayout">
+                  <item>
+                   <widget class="QPushButton" name="addGroupingParameterButton">
+                    <property name="maximumSize">
+                     <size>
+                      <width>16777215</width>
+                      <height>16777215</height>
+                     </size>
+                    </property>
+                    <property name="text">
+                     <string>+</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="removeGroupingParameterButton">
+                    <property name="maximumSize">
+                     <size>
+                      <width>16777215</width>
+                      <height>16777215</height>
+                     </size>
+                    </property>
+                    <property name="text">
+                     <string>-</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
               </widget>
              </item>
             </layout>
@@ -1251,8 +1251,8 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>62</width>
-       <height>781</height>
+       <width>16777215</width>
+       <height>16777215</height>
       </size>
      </property>
      <property name="title">


### PR DESCRIPTION
Implemented toggling the visibility of the grouping parameter panel within the `InstrumentWidget` - also resolved some layout problems with maximum size constraints on widgets.

One issue is present, that making the grouping parameter panel enlarges all of the group boxes, and then hiding the grouping parameter panel again does not revert these changes.
