### PR TITLE
Handle FILE for Total Cross Section Source

### DIFF
--- a/src/gui/widgets/container_widget.py
+++ b/src/gui/widgets/container_widget.py
@@ -43,6 +43,10 @@ class ContainerWidget(QWidget):
         Slot for handling change in the density.
     handleTotalCrossSectionChanged(index)
         Slot for handling change in the total cross section source.
+    handleCrossSectionFileChanged(value)
+        Slot for handling change in total cross section source file name.
+    handleBrowseCrossSectionFile()
+        Slot for browsing for a cross section source file.
     handleTweakFactorChanged(value)
         Slot for handling change in the sample tweak factor.
     handleAngleOfRotationChanged(value)
@@ -218,7 +222,7 @@ class ContainerWidget(QWidget):
 
     def handleTotalCrossSectionChanged(self, index):
         """
-        Slot for handling change in total cross ection source.
+        Slot for handling change in total cross section source.
         Called when a currentIndexChanged signal is emitted,
         from the totalCrossSectionComboBox.
         Alters the container's total cross section source as such.
@@ -230,8 +234,39 @@ class ContainerWidget(QWidget):
         self.container.totalCrossSectionSource = (
             self.totalCrossSectionComboBox.itemData(index)
         )
+        self.crossSectionFileWidget.setVisible(
+            self.container.totalCrossSectionSource == CrossSectionSource.FILE
+        )
         if not self.widgetsRefreshing:
             self.parent.setModified()
+
+    def handleCrossSectionFileChanged(self, value):
+        """
+        Slot for handling change in total cross section source file name.
+        Called when a textChanged signal is emitted,
+        from the crossSectionFileLineEdit.
+        Alters the container's total cross section source file name as such.
+        Parameters
+        ----------
+        value : str
+            The new text of the crossSectionFileLineEdit.
+        """
+        self.container.crossSectionFilename = value
+        if not self.widgetsRefreshing:
+            self.parent.setModified() 
+
+    def handleBrowseCrossSectionFile(self):
+        """
+        Slot for browsing for a cross section source file.
+        Called when a clicked signal is emitted,
+        from the browseCrossSectionFileButton.
+        Alters the corresponding line edit as such.
+        as such.
+        """
+        filename, _ = QFileDialog.getOpenFileName(
+            self, "Total cross section source", "")
+        if filename:
+            self.crossSectionFileLineEdit.setText(filename)
 
     def handleTweakFactorChanged(self, value):
         """
@@ -514,6 +549,15 @@ class ContainerWidget(QWidget):
         self.totalCrossSectionComboBox.currentIndexChanged.connect(
             self.handleTotalCrossSectionChanged
         )
+
+        self.crossSectionFileLineEdit.textChanged.connect(
+            self.handleCrossSectionFileChanged
+        )
+
+        self.browseCrossSectionFileButton.clicked.connect(
+            self.handleBrowseCrossSectionFile
+        )
+
         self.tweakFactorSpinBox.valueChanged.connect(
             self.handleTweakFactorChanged
         )
@@ -572,7 +616,12 @@ class ContainerWidget(QWidget):
         self.totalCrossSectionComboBox.setCurrentIndex(
             self.container.totalCrossSectionSource.value
         )
-
+        self.crossSectionFileLineEdit.setText(
+            self.container.crossSectionFilename
+        )
+        self.crossSectionFileWidget.setVisible(
+            self.container.totalCrossSectionSource == CrossSectionSource.FILE
+        )
         self.tweakFactorSpinBox.setValue(self.container.tweakFactor)
 
         self.scatteringFractionSpinBox.setValue(

--- a/src/gui/widgets/container_widget.py
+++ b/src/gui/widgets/container_widget.py
@@ -253,7 +253,7 @@ class ContainerWidget(QWidget):
         """
         self.container.crossSectionFilename = value
         if not self.widgetsRefreshing:
-            self.parent.setModified() 
+            self.parent.setModified()
 
     def handleBrowseCrossSectionFile(self):
         """

--- a/src/gui/widgets/normalisation_widget.py
+++ b/src/gui/widgets/normalisation_widget.py
@@ -45,6 +45,10 @@ class NormalisationWidget(QWidget):
         Slot for handling change in the density.
     handleTotalCrossSectionChanged(index)
         Slot for handling change in the total cross section source.
+    handleCrossSectionFileChanged(value)
+        Slot for handling change in total cross section source file name.
+    handleBrowseCrossSectionFile()
+        Slot for browsing for a cross section source file.
     handleForceCorrectionsSwitched(state)
         Slot for handling switching forcing correction calculations on/off.
     handlePlaczekCorrectionChanged(value)
@@ -280,8 +284,39 @@ class NormalisationWidget(QWidget):
         self.normalisation.totalCrossSectionSource = (
             self.totalCrossSectionComboBox.itemData(index)
         )
+        self.crossSectionFileWidget.setVisible(
+            self.normalisation.totalCrossSectionSource == CrossSectionSource.FILE
+        )
         if not self.widgetsRefreshing:
             self.parent.setModified()
+
+    def handleCrossSectionFileChanged(self, value):
+        """
+        Slot for handling change in total cross section source file name.
+        Called when a textChanged signal is emitted,
+        from the crossSectionFileLineEdit.
+        Alters the normalisation's total cross section source file name as such.
+        Parameters
+        ----------
+        value : str
+            The new text of the crossSectionFileLineEdit.
+        """
+        self.normalisation.crossSectionFilename = value
+        if not self.widgetsRefreshing:
+            self.parent.setModified() 
+
+    def handleBrowseCrossSectionFile(self):
+        """
+        Slot for browsing for a cross section source file.
+        Called when a clicked signal is emitted,
+        from the browseCrossSectionFileButton.
+        Alters the corresponding line edit as such.
+        as such.
+        """
+        filename, _ = QFileDialog.getOpenFileName(
+            self, "Total cross section source", "")
+        if filename:
+            self.crossSectionFileLineEdit.setText(filename)
 
     def handleForceCorrectionsSwitched(self, state):
         """
@@ -714,6 +749,18 @@ class NormalisationWidget(QWidget):
         )
         self.totalCrossSectionComboBox.currentIndexChanged.connect(
             self.handleTotalCrossSectionChanged
+        )
+        self.crossSectionFileLineEdit.setText(
+            self.normalisation.crossSectionFilename
+        )
+        self.crossSectionFileLineEdit.textChanged.connect(
+            self.handleCrossSectionFileChanged
+        )
+        self.browseCrossSectionFileButton.clicked.connect(
+            self.handleBrowseCrossSectionFile
+        )
+        self.crossSectionFileWidget.setVisible(
+            self.normalisation.totalCrossSectionSource == CrossSectionSource.FILE
         )
 
         self.forceCorrectionsCheckBox.setChecked(

--- a/src/gui/widgets/normalisation_widget.py
+++ b/src/gui/widgets/normalisation_widget.py
@@ -285,7 +285,8 @@ class NormalisationWidget(QWidget):
             self.totalCrossSectionComboBox.itemData(index)
         )
         self.crossSectionFileWidget.setVisible(
-            self.normalisation.totalCrossSectionSource == CrossSectionSource.FILE
+            self.normalisation.totalCrossSectionSource ==
+            CrossSectionSource.FILE
         )
         if not self.widgetsRefreshing:
             self.parent.setModified()
@@ -295,7 +296,8 @@ class NormalisationWidget(QWidget):
         Slot for handling change in total cross section source file name.
         Called when a textChanged signal is emitted,
         from the crossSectionFileLineEdit.
-        Alters the normalisation's total cross section source file name as such.
+        Alters the normalisation's total cross
+        section source file name as such.
         Parameters
         ----------
         value : str
@@ -303,7 +305,7 @@ class NormalisationWidget(QWidget):
         """
         self.normalisation.crossSectionFilename = value
         if not self.widgetsRefreshing:
-            self.parent.setModified() 
+            self.parent.setModified()
 
     def handleBrowseCrossSectionFile(self):
         """
@@ -760,7 +762,8 @@ class NormalisationWidget(QWidget):
             self.handleBrowseCrossSectionFile
         )
         self.crossSectionFileWidget.setVisible(
-            self.normalisation.totalCrossSectionSource == CrossSectionSource.FILE
+            self.normalisation.totalCrossSectionSource ==
+            CrossSectionSource.FILE
         )
 
         self.forceCorrectionsCheckBox.setChecked(

--- a/src/gui/widgets/sample_widget.py
+++ b/src/gui/widgets/sample_widget.py
@@ -54,6 +54,10 @@ class SampleWidget(QWidget):
         Slot for handling change to the density units.
     handleTotalCrossSectionChanged(index)
         Slot for handling change in the total cross section source.
+    handleCrossSectionFileChanged(value)
+        Slot for handling change in total cross section source file name.
+    handleBrowseCrossSectionFile()
+        Slot for browsing for a cross section source file.
     handleTweakFactorChanged(value)
         Slot for handling change in the sample tweak factor.
     handleTopHatWidthChanged(value)
@@ -299,8 +303,39 @@ class SampleWidget(QWidget):
         self.sample.totalCrossSectionSource = (
             self.totalCrossSectionComboBox.itemData(index)
         )
+        self.crossSectionFileWidget.setVisible(
+            self.sample.totalCrossSectionSource == CrossSectionSource.FILE
+        )
         if not self.widgetsRefreshing:
             self.parent.setModified()
+
+    def handleCrossSectionFileChanged(self, value):
+        """
+        Slot for handling change in total cross section source file name.
+        Called when a textChanged signal is emitted,
+        from the crossSectionFileLineEdit.
+        Alters the sample's total cross section source file name as such.
+        Parameters
+        ----------
+        value : str
+            The new text of the crossSectionFileLineEdit.
+        """
+        self.sample.crossSectionFilename = value
+        if not self.widgetsRefreshing:
+            self.parent.setModified()
+
+    def handleBrowseCrossSectionFile(self):
+        """
+        Slot for browsing for a cross section source file.
+        Called when a clicked signal is emitted,
+        from the browseCrossSectionFileButton.
+        Alters the corresponding line edit as such.
+        as such.
+        """
+        filename, _ = QFileDialog.getOpenFileName(
+            self, "Total cross section source", "")
+        if filename:
+            self.crossSectionFileLineEdit.setText(filename)
 
     def handleTweakFactorChanged(self, value):
         """
@@ -792,6 +827,12 @@ class SampleWidget(QWidget):
         self.totalCrossSectionComboBox.currentIndexChanged.connect(
             self.handleCrossSectionSourceChanged
         )
+        self.crossSectionFileLineEdit.textChanged.connect(
+            self.handleCrossSectionFileChanged
+        )
+        self.browseCrossSectionFileButton.clicked.connect(
+            self.handleBrowseCrossSectionFile
+        )
 
         # Fill the normalisation type combo box.
         for n in NormalisationType:
@@ -917,6 +958,12 @@ class SampleWidget(QWidget):
 
         self.totalCrossSectionComboBox.setCurrentIndex(
             self.sample.totalCrossSectionSource.value
+        )
+        self.crossSectionFileLineEdit.setText(
+            self.sample.crossSectionFilename
+        )
+        self.crossSectionFileWidget.setVisible(
+            self.sample.totalCrossSectionSource == CrossSectionSource.FILE
         )
 
         self.normaliseToComboBox.setCurrentIndex(self.sample.normaliseTo.value)

--- a/src/gui/widgets/ui_files/containerWidget.ui
+++ b/src/gui/widgets/ui_files/containerWidget.ui
@@ -25,7 +25,10 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_6">
+  <layout class="QVBoxLayout" name="verticalLayout_5">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_4"/>
+   </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
@@ -199,17 +202,7 @@
           <property name="labelAlignment">
            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
           </property>
-          <item row="0" column="1">
-           <widget class="QComboBox" name="totalCrossSectionComboBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
+          <item row="0" column="0">
            <widget class="QLabel" name="scatteringFractionLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -222,7 +215,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="0" column="1">
            <widget class="QDoubleSpinBox" name="scatteringFractionSpinBox">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -232,7 +225,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="1" column="0">
            <widget class="QLabel" name="attenuationCoefficientLabel">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -245,26 +238,13 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="1" column="1">
            <widget class="QDoubleSpinBox" name="attenuationCoefficientSpinBox">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="totalCrossSectionSourceLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Total Cross Section Source</string>
             </property>
            </widget>
           </item>
@@ -276,7 +256,7 @@
     </layout>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <layout class="QHBoxLayout" name="horizontalLayout_7">
      <item>
       <widget class="QGroupBox" name="compositionComboBox">
        <property name="sizePolicy">
@@ -456,6 +436,64 @@
            </spacer>
           </item>
          </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QLabel" name="totalCrossSectionSourceLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Total Cross Section Source</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="totalCrossSectionComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QWidget" name="crossSectionFileWidget" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLineEdit" name="crossSectionFileLineEdit"/>
+           </item>
+           <item>
+            <widget class="QPushButton" name="browseCrossSectionFileButton">
+             <property name="text">
+              <string>Browse</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </item>
        </layout>
       </widget>
@@ -710,24 +748,13 @@
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>20</width>
-       <height>40</height>
+       <width>17</width>
+       <height>68</height>
       </size>
      </property>
     </spacer>
    </item>
   </layout>
-  <widget class="QWidget" name="layoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>2</width>
-     <height>2</height>
-    </rect>
-   </property>
-   <layout class="QHBoxLayout" name="horizontalLayout_4"/>
-  </widget>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/gui/widgets/ui_files/normalisationWidget.ui
+++ b/src/gui/widgets/ui_files/normalisationWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>733</width>
-    <height>791</height>
+    <height>803</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -406,6 +406,25 @@
            </widget>
           </item>
          </layout>
+        </item>
+        <item>
+         <widget class="QWidget" name="crossSectionFileWidget" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout_19">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLineEdit" name="crossSectionFileLineEdit"/>
+           </item>
+           <item>
+            <widget class="QPushButton" name="browseCrossSectionFileButton">
+             <property name="text">
+              <string>Browse</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </item>
        </layout>
       </widget>

--- a/src/gui/widgets/ui_files/sampleWidget.ui
+++ b/src/gui/widgets/ui_files/sampleWidget.ui
@@ -357,6 +357,37 @@
               </item>
              </layout>
             </item>
+            <item>
+             <widget class="QWidget" name="crossSectionFileWidget" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_22">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QLineEdit" name="crossSectionFileLineEdit"/>
+               </item>
+               <item>
+                <widget class="QPushButton" name="browseCrossSectionFileButton">
+                 <property name="text">
+                  <string>Browse</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>


### PR DESCRIPTION
Implemented handling choosing the FILE option for the Total Cross Section Source.
If the FILE option is selected, a hidden widget is made visible which allows browsing for a file, it gets hidden again if a different option is chosen in the combo box.

Closes #92.
