### PR TITLE
Zoom charts

### DIFF
--- a/src/gui/widgets/gudpy_charts.py
+++ b/src/gui/widgets/gudpy_charts.py
@@ -1,6 +1,6 @@
 from PySide6.QtCharts import QChart, QChartView, QLineSeries
-from PySide6.QtCore import QPoint, QPointF, QRect, QRectF, Qt
-from PySide6.QtGui import QAction, QCursor, QMouseEvent
+from PySide6.QtCore import QRectF, Qt
+from PySide6.QtGui import QAction, QCursor
 from enum import Enum
 import os
 
@@ -217,6 +217,7 @@ class GudPyChart(QChart):
             for sample in samples:
                 self.plotSample(sample, plotMode, dataFileType, inputDir)
 
+
 class GudPyChartView(QChartView):
     """
     Class to represent a GudPyChartView. Inherits QChartView.
@@ -234,12 +235,30 @@ class GudPyChartView(QChartView):
         Sets the chart.
     """
     def __init__(self, parent):
+        """
+        Constructs all the necessary attributes for the GudPyChartView object.
+        Calls super()._init__ which calls the dunder init method
+        from QChartView.
+        Parameters
+        ----------
+        parent : QWidget, optional
+            Parent widget.
+        """
         super(GudPyChartView, self).__init__(parent=parent)
         self.chart = None
+
+        # Enable rectangualar rubber banding.
         self.setRubberBand(QChartView.RectangleRubberBand)
 
     def wheelEvent(self, event):
-
+        """
+        Event handler called when the scroll wheel is used.
+        This event is overridden for zooming in/out.
+        Parameters
+        ----------
+        event : QWheelEvent
+            Event that triggered the function call.
+        """
         # Decide on the zoom factor.
         # If y > 0, zoom in, if y < 0 zoom out.
         zoomFactor = 2.0 if event.angleDelta().y() > 0 else 0.5
@@ -264,10 +283,25 @@ class GudPyChartView(QChartView):
         self.chart.scroll(delta.x(), -delta.y())
 
     def setChart(self, chart):
+        """
+        Sets the chart in the chartview.
+        Parameters
+        ----------
+        chart : GudPyChart
+            Chart to be set.
+        """
         self.chart = chart
         return super().setChart(chart)
-    
+
     def contextMenuEvent(self, event):
+        """
+        Creates context menu, so that on right clicking the chartview,
+        the user is able to perform actions.
+        Parameters
+        ----------
+        event : QMouseEvent
+            The event that triggers the context menu.
+        """
         self.menu = QMenu(self)
         resetAction = QAction("Reset zoom", self.menu)
         resetAction.triggered.connect(self.chart.zoomReset)
@@ -275,6 +309,17 @@ class GudPyChartView(QChartView):
         self.menu.popup(QCursor.pos())
 
     def mouseReleaseEvent(self, event):
+        """
+        Event handler called when a mouse button is released.
+        This event is overridden to stop hard zooming out on right click.
+        Parameters
+        ----------
+        event : QMouseEvent
+            Event that triggered the function call.
+        """
+
+        # If the button that triggered the event is the right button,
+        # then ignore the event.
         if event.button() == Qt.MouseButton.RightButton:
             event.ignore()
         else:

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -140,7 +140,9 @@ class GudPyMainWindow(QMainWindow):
         self.mainWidget.statusBar_.addWidget(self.mainWidget.statusBarWidget)
         self.mainWidget.setStatusBar(self.mainWidget.statusBar_)
 
-        self.mainWidget.sampleStructureFactorChartView = GudPyChartView(self.mainWidget)
+        self.mainWidget.sampleStructureFactorChartView = GudPyChartView(
+            self.mainWidget
+        )
 
         self.mainWidget.sampleStructureFactorChartView.setRenderHint(
             QPainter.Antialiasing
@@ -162,7 +164,9 @@ class GudPyMainWindow(QMainWindow):
 
         self.mainWidget.plotsLayout = QVBoxLayout(self.mainWidget.plotTab)
 
-        self.mainWidget.allSampleStructureFactorChartView = GudPyChartView(self.mainWidget)
+        self.mainWidget.allSampleStructureFactorChartView = GudPyChartView(
+            self.mainWidget
+        )
 
         self.mainWidget.allSampleStructureFactorChartView.setRenderHint(
             QPainter.Antialiasing


### PR DESCRIPTION
This PR enables zooming in/out of the charts using the scroll wheel, closing #156.
Also stops hard zooming out on right click, closing #157.
Implements a context menu for resetting the zoom - this can be extended with further functionality later on.