### PR TITLE
Set working dir

### DIFF
--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -1272,7 +1272,7 @@ class GudrunFile:
         None
         """
         if not overwrite:
-            f = open(self.outpath, "w", encoding="utf-8")
+            f = open(os.path.join(self.instrument.GudrunInputFileDir, self.outpath), "w", encoding="utf-8")
         else:
             f = open(self.path, "w", encoding="utf-8")
         f.write(str(self))
@@ -1322,7 +1322,7 @@ class GudrunFile:
                 proc = QProcess()
                 proc.setProgram(gudrun_dcs)
                 proc.setArguments([path])
-                return proc
+                return proc, self.write_out, [os.path.join(self.instrument.GudrunInputFileDir, "gudpy.txt")]
 
     def process(self, headless=True):
         """

--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -1272,7 +1272,11 @@ class GudrunFile:
         None
         """
         if not overwrite:
-            f = open(os.path.join(self.instrument.GudrunInputFileDir, self.outpath), "w", encoding="utf-8")
+            f = open(
+                os.path.join(
+                    self.instrument.GudrunInputFileDir,
+                    self.outpath
+                ), "w", encoding="utf-8")
         else:
             f = open(self.path, "w", encoding="utf-8")
         f.write(str(self))
@@ -1322,7 +1326,16 @@ class GudrunFile:
                 proc = QProcess()
                 proc.setProgram(gudrun_dcs)
                 proc.setArguments([path])
-                return proc, self.write_out, [os.path.join(self.instrument.GudrunInputFileDir, "gudpy.txt")]
+                return (
+                    proc,
+                    self.write_out,
+                    [
+                        os.path.join(
+                            self.instrument.GudrunInputFileDir,
+                            "gudpy.txt"
+                        )
+                    ]
+                )
 
     def process(self, headless=True):
         """

--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -1317,7 +1317,7 @@ class GudrunFile:
             else:
                 gudrun_dcs = resolve("bin", f"gudrun_dcs{SUFFIX}")
             if not os.path.exists(gudrun_dcs):
-                return False
+                return FileNotFoundError()
             else:
                 proc = QProcess()
                 proc.setProgram(gudrun_dcs)

--- a/src/gudrun_classes/purge_file.py
+++ b/src/gudrun_classes/purge_file.py
@@ -314,4 +314,13 @@ class PurgeFile():
             proc = QProcess()
             proc.setProgram(purge_det)
             proc.setArguments([])
-            return proc, self.write_out, [os.path.join(self.gudrunFile.instrument.GudrunInputFileDir, "purge_det.dat")]
+            return (
+                proc,
+                self.write_out,
+                [
+                    os.path.join(
+                        self.gudrunFile.instrument.GudrunInputFileDir,
+                        "purge_det.dat"
+                    )
+                ]
+            )

--- a/src/gudrun_classes/purge_file.py
+++ b/src/gudrun_classes/purge_file.py
@@ -310,7 +310,7 @@ class PurgeFile():
             else:
                 purge_det = resolve("bin", f"purge_det{SUFFIX}")
             if not os.path.exists(purge_det):
-                return False
+                return FileNotFoundError()
             proc = QProcess()
             proc.setProgram(purge_det)
             proc.setArguments([])

--- a/src/gudrun_classes/purge_file.py
+++ b/src/gudrun_classes/purge_file.py
@@ -90,7 +90,7 @@ class PurgeFile():
         self.standardDeviation = (10, 10)
         self.ignoreBad = True
 
-    def write_out(self):
+    def write_out(self, path=""):
         """
         Writes out the string representation of the PurgeFile to
         purge_det.dat.
@@ -104,8 +104,12 @@ class PurgeFile():
         """
         # Write out the string representation of the PurgeFile
         # To purge_det.dat.
-        f = open("purge_det.dat", "w", encoding="utf-8")
-        f.write(str(self))
+        if not path:
+            f = open("purge_det.dat", "w", encoding="utf-8")
+            f.write(str(self))
+        else:
+            f = open(path, "w", encoding="utf-8")
+            f.write(str(self))
         f.close()
 
     def __str__(self):
@@ -310,4 +314,4 @@ class PurgeFile():
             proc = QProcess()
             proc.setProgram(purge_det)
             proc.setArguments([])
-            return proc
+            return proc, self.write_out, [os.path.join(self.gudrunFile.instrument.GudrunInputFileDir, "purge_det.dat")]

--- a/src/gui/widgets/dialogs/iteration_dialog.py
+++ b/src/gui/widgets/dialogs/iteration_dialog.py
@@ -112,7 +112,7 @@ class IterationDialog(QDialog):
                 self.queue = Queue()
                 for i in range(self.numberIterations):
                     self.queue.put(
-                        self.gudrunFile.dcs(path="gudpy.txt", headless=False)
+                        self.gudrunFile.dcs(path=os.path.join(self.gudrunFile.instrument.GudrunInputFileDir, "gudpy.txt"), headless=False)
                     )
                 self.text = "Tweak by tweak factor"
                 self.widget.close()

--- a/src/gui/widgets/dialogs/iteration_dialog.py
+++ b/src/gui/widgets/dialogs/iteration_dialog.py
@@ -128,7 +128,7 @@ class IterationDialog(QDialog):
                     path="gudpy.txt", headless=False)
                 )
                 self.queue.put(
-                    self.gudrunFile.dcs(path="gudpy.txt", headless=False)
+                    self.gudrunFile.dcs(path=os.path.join(self.gudrunFile.instrument.GudrunInputFileDir, "gudpy.txt"), headless=False)
                 )
             self.text = "Inelasticity subtractions"
             self.widget.close()

--- a/src/gui/widgets/dialogs/iteration_dialog.py
+++ b/src/gui/widgets/dialogs/iteration_dialog.py
@@ -110,9 +110,13 @@ class IterationDialog(QDialog):
             if self.tweak == Iterables.TWEAK_FACTOR:
                 self.iterator = TweakFactorIterator(self.gudrunFile)
                 self.queue = Queue()
-                for i in range(self.numberIterations):
+                for _ in range(self.numberIterations):
                     self.queue.put(
-                        self.gudrunFile.dcs(path=os.path.join(self.gudrunFile.instrument.GudrunInputFileDir, "gudpy.txt"), headless=False)
+                        self.gudrunFile.dcs(
+                            path=os.path.join(
+                                self.gudrunFile.instrument.GudrunInputFileDir,
+                                "gudpy.txt"
+                            ), headless=False)
                     )
                 self.text = "Tweak by tweak factor"
                 self.widget.close()
@@ -123,12 +127,16 @@ class IterationDialog(QDialog):
                 self.gudrunFile
             )
             self.queue = Queue()
-            for i in range(self.numberIterations):
+            for _ in range(self.numberIterations):
                 self.queue.put(self.gudrunFile.dcs(
                     path="gudpy.txt", headless=False)
                 )
                 self.queue.put(
-                    self.gudrunFile.dcs(path=os.path.join(self.gudrunFile.instrument.GudrunInputFileDir, "gudpy.txt"), headless=False)
+                    self.gudrunFile.dcs(
+                        path=os.path.join(
+                            self.gudrunFile.instrument.GudrunInputFileDir,
+                            "gudpy.txt"
+                        ), headless=False)
                 )
             self.text = "Inelasticity subtractions"
             self.widget.close()

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -68,7 +68,7 @@ import sys
 import math
 import traceback
 from queue import Queue
-
+from collections.abc import Sequence
 
 class GudPyMainWindow(QMainWindow):
     """
@@ -630,7 +630,7 @@ class GudPyMainWindow(QMainWindow):
         self.setControlsEnabled(False)
         purgeDialog = PurgeDialog(self.gudrunFile, self)
         result = purgeDialog.widget.exec_()
-        purge, func, args = purgeDialog.purge_det
+        purge = purgeDialog.purge_det
         if purgeDialog.cancelled or result == QDialogButtonBox.No:
             self.setControlsEnabled(True)
             self.queue = Queue()
@@ -641,6 +641,7 @@ class GudPyMainWindow(QMainWindow):
             )
             self.setControlsEnabled(True)
         else:
+            purge, func, args = purge
             self.makeProc(purge, self.progressPurge, func, args)
 
     def runGudrun_(self):
@@ -908,7 +909,6 @@ class GudPyMainWindow(QMainWindow):
     def progressIncrementPurge(self):
         data = self.proc.readAllStandardOutput()
         stdout = bytes(data).decode("utf8")
-        print(stdout)
         dataFiles = [self.gudrunFile.instrument.groupFileName]
 
         def appendDfs(dfs):

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -70,6 +70,7 @@ import traceback
 from queue import Queue
 from collections.abc import Sequence
 
+
 class GudPyMainWindow(QMainWindow):
     """
     Class to represent the GudPyMainWindow. Inherits QMainWindow.
@@ -621,7 +622,9 @@ class GudPyMainWindow(QMainWindow):
         self.proc.readyReadStandardOutput.connect(slot)
         self.proc.started.connect(self.procStarted)
         self.proc.finished.connect(self.procFinished)
-        self.proc.setWorkingDirectory(self.gudrunFile.instrument.GudrunInputFileDir)
+        self.proc.setWorkingDirectory(
+            self.gudrunFile.instrument.GudrunInputFileDir
+        )
         if func:
             func(*args)
         self.proc.start()
@@ -649,7 +652,13 @@ class GudPyMainWindow(QMainWindow):
 
     def runGudrun_(self):
         self.setControlsEnabled(False)
-        dcs = self.gudrunFile.dcs(path=os.path.join(self.gudrunFile.instrument.GudrunInputFileDir, self.gudrunFile.outpath), headless=False)
+        dcs = self.gudrunFile.dcs(
+            path=os.path.join(
+                self.gudrunFile.instrument.GudrunInputFileDir,
+                self.gudrunFile.outpath
+            ),
+            headless=False
+        )
         if isinstance(dcs, Sequence):
             dcs, func, args = dcs
         if isinstance(dcs, FileNotFoundError):
@@ -657,7 +666,15 @@ class GudPyMainWindow(QMainWindow):
                 self.mainWidget, "GudPy Error",
                 "Couldn't find gudrun_dcs binary."
             )
-        elif not self.gudrunFile.purged and os.path.exists(os.path.join(self.gudrunFile.instrument.GudrunInputFileDir, 'purge_det.dat')):
+        elif (
+            not self.gudrunFile.purged
+            and os.path.exists(
+                os.path.join(
+                    self.gudrunFile.instrument.GudrunInputFileDir,
+                    'purge_det.dat'
+                )
+            )
+        ):
             self.purgeOptionsMessageBox(
                 dcs, func, args,
                 "purge_det.dat found, but wasn't run in this session. "
@@ -710,7 +727,13 @@ class GudPyMainWindow(QMainWindow):
             self.makeProc(purge, self.progressPurge, func, args)
         else:
             self.runPurge_()
-        dcs = self.gudrunFile.dcs(path=os.path.join(self.gudrunFile.instrument.GudrunInputFileDir, self.gudrunFile.outpath), headless=False)
+        dcs = self.gudrunFile.dcs(
+            path=os.path.join(
+                self.gudrunFile.instrument.GudrunInputFileDir,
+                self.gudrunFile.outpath
+            ),
+            headless=False
+        )
         if isinstance(dcs, Sequence):
             dcs, func, args = dcs
         elif isinstance(dcs, FileNotFoundError):

--- a/src/gui/widgets/slots/beam_slots.py
+++ b/src/gui/widgets/slots/beam_slots.py
@@ -1,4 +1,4 @@
-from src.gudrun_classes.enums import Geometry
+from src.gudrun_classes.enums import Geometry, Instruments
 from src.gudrun_classes import config
 from PySide6.QtWidgets import QFileDialog
 
@@ -398,8 +398,14 @@ class BeamSlots():
         Alters the corresponding line edit as such.
         as such.
         """
+        import os
+        instrumentFilesDir = os.path.join(
+            self.parent.gudrunFile.instrument.GudrunStartFolder,
+            self.parent.gudrunFile.instrument.startupFileFolder,
+            Instruments(self.parent.gudrunFile.instrument.name.value).name
+        )
         filename, _ = QFileDialog.getOpenFileName(
-            self.widget, "Incident beam spectrum parameters", "")
+            self.widget, "Incident beam spectrum parameters", instrumentFilesDir)
         if filename:
             (
                 self.widget.incidentBeamSpectrumParametersLineEdit

--- a/src/gui/widgets/slots/beam_slots.py
+++ b/src/gui/widgets/slots/beam_slots.py
@@ -405,7 +405,10 @@ class BeamSlots():
             Instruments(self.parent.gudrunFile.instrument.name.value).name
         )
         filename, _ = QFileDialog.getOpenFileName(
-            self.widget, "Incident beam spectrum parameters", instrumentFilesDir)
+            self.widget,
+            "Incident beam spectrum parameters",
+            instrumentFilesDir
+        )
         if filename:
             (
                 self.widget.incidentBeamSpectrumParametersLineEdit

--- a/tests/test_gudpy_io.py
+++ b/tests/test_gudpy_io.py
@@ -747,7 +747,14 @@ class TestGudPyIO(TestCase):
         g1.write_out()
 
         self.assertEqual(
-            open(g1.outpath, encoding="utf-8").read()[:-5], str(self.g)[:-5]
+            open(
+                os.path.join(
+                    g1.instrument.GudrunInputFileDir,
+                    g1.outpath
+                ),
+                encoding="utf-8"
+            ).read()[:-5],
+            str(self.g)[:-5]
         )
         self.assertEqual(
             open(g1.outpath, encoding="utf-8").read()[:-5], str(g1)[:-5]

--- a/tests/test_gudpy_io.py
+++ b/tests/test_gudpy_io.py
@@ -737,8 +737,10 @@ class TestGudPyIO(TestCase):
 
     def testRewriteGudrunFile(self):
         self.g.write_out()
-        g1 = GudrunFile(os.path.join(
-            self.g.outpath, self.g.instrument.GudrunInputFileDir
+        g1 = GudrunFile(
+            os.path.join(
+                self.g.instrument.GudrunInputFileDir,
+                self.g.outpath
             )
         )
         g1.instrument.GudrunInputFileDir = self.g.instrument.GudrunInputFileDir
@@ -757,8 +759,10 @@ class TestGudPyIO(TestCase):
 
     def testReloadGudrunFile(self):
         self.g.write_out()
-        g1 = GudrunFile(os.path.join(
-            self.g.outpath, self.g.instrument.GudrunInputFileDir
+        g1 = GudrunFile(
+            os.path.join(
+                self.g.instrument.GudrunInputFileDir,
+                self.g.outpath
             )
         )
         g1.instrument.GudrunInputFileDir = self.g.instrument.GudrunInputFileDir

--- a/tests/test_gudpy_io.py
+++ b/tests/test_gudpy_io.py
@@ -754,7 +754,7 @@ class TestGudPyIO(TestCase):
         )
         self.assertEqual(
             open(g1.outpath, encoding="utf-8").read()[:-5],
-            open(self.g.outpath, encoding="utf-8").read()[:-5],
+            open(g1.path, encoding="utf-8").read()[:-5],
         )
 
     def testReloadGudrunFile(self):

--- a/tests/test_gudpy_io.py
+++ b/tests/test_gudpy_io.py
@@ -756,9 +756,18 @@ class TestGudPyIO(TestCase):
             ).read()[:-5],
             str(self.g)[:-5]
         )
+
         self.assertEqual(
-            open(g1.outpath, encoding="utf-8").read()[:-5], str(g1)[:-5]
+            open(
+                os.path.join(
+                    g1.instrument.GudrunInputFileDir,
+                    g1.outpath
+                ),
+                encoding="utf-8"
+            ).read()[:-5],
+            str(g1)[:-5]
         )
+
         self.assertEqual(
             open(
                 os.path.join(

--- a/tests/test_gudpy_io.py
+++ b/tests/test_gudpy_io.py
@@ -753,8 +753,19 @@ class TestGudPyIO(TestCase):
             open(g1.outpath, encoding="utf-8").read()[:-5], str(g1)[:-5]
         )
         self.assertEqual(
-            open(g1.outpath, encoding="utf-8").read()[:-5],
-            open(g1.path, encoding="utf-8").read()[:-5],
+            open(
+                os.path.join(
+                    g1.instrument.GudrunInputFileDir,
+                    g1.outpath
+                ),
+                encoding="utf-8"
+            ).read()[:-5],
+            open(os.path.join(
+                    self.g.instrument.GudrunInputFileDir,
+                    self.g.outpath
+                ),
+                encoding="utf-8"
+            ).read()[:-5],
         )
 
     def testReloadGudrunFile(self):

--- a/tests/test_gudpy_io.py
+++ b/tests/test_gudpy_io.py
@@ -653,7 +653,13 @@ class TestGudPyIO(TestCase):
 
     def testWriteGudrunFile(self):
         self.g.write_out()
-        outlines = open(self.g.outpath, encoding="utf-8").read()
+        outlines = open(
+            os.path.join(
+                self.g.instrument.GudrunInputFileDir,
+                self.g.outpath
+            ),
+            encoding="utf-8"
+        ).read()
         self.assertEqual(outlines, str(self.g))
 
         def valueInLines(value, lines):
@@ -731,7 +737,10 @@ class TestGudPyIO(TestCase):
 
     def testRewriteGudrunFile(self):
         self.g.write_out()
-        g1 = GudrunFile(self.g.outpath)
+        g1 = GudrunFile(os.path.join(
+            self.g.outpath, self.g.instrument.GudrunInputFileDir
+            )
+        )
         g1.instrument.GudrunInputFileDir = self.g.instrument.GudrunInputFileDir
         g1.write_out()
 
@@ -748,7 +757,10 @@ class TestGudPyIO(TestCase):
 
     def testReloadGudrunFile(self):
         self.g.write_out()
-        g1 = GudrunFile(self.g.outpath)
+        g1 = GudrunFile(os.path.join(
+            self.g.outpath, self.g.instrument.GudrunInputFileDir
+            )
+        )
         g1.instrument.GudrunInputFileDir = self.g.instrument.GudrunInputFileDir
         self.assertEqual(str(g1), str(self.g))
 


### PR DESCRIPTION
PR to implement setting the working directory using `QProcess.setWorkingDirectory`. Closes #240.
Also fixed issue with cancelling the purge dialog producing a warning for the `purge_det` binary missing. Closes #242.