### PR TITLE
Use relative paths

### DIFF
--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -32,7 +32,7 @@ from src.gudrun_classes.enums import (
     Geometry
 )
 from src.gudrun_classes import config
-
+import re
 
 SUFFIX = ".exe" if os.name == "nt" else ""
 
@@ -395,6 +395,27 @@ class GudrunFile:
             # Consume whitespace and the closing brace.
             self.consumeUpToDelim("}")
 
+            # Resolve the paths, to make them relative.
+            # First construct the regular expression to match against.
+            pattern = re.compile(r"StartupFiles\S*")
+
+            self.instrument.detectorCalibrationFileName = (
+                re.search(pattern, self.instrument.detectorCalibrationFileName).group()
+            )
+
+            self.instrument.groupFileName = (
+                re.search(pattern, self.instrument.groupFileName).group()
+            )
+
+            self.instrument.deadtimeConstantsFileName = (
+                re.search(pattern, self.instrument.deadtimeConstantsFileName).group()
+            )
+
+            self.instrument.neutronScatteringParametersFile = (
+                re.search(pattern, self.instrument.neutronScatteringParametersFile).group()
+            )
+
+
         except Exception as e:
             raise ParserException(
                     "Whilst parsing Instrument, an exception occured."
@@ -473,6 +494,13 @@ class GudrunFile:
             # we simply extract the firstword in the line.
             self.beam.filenameIncidentBeamSpectrumParams = (
                 firstword(self.getNextToken())
+            )
+
+            # Now match it against a pattern, to resolve the path to be relative.
+            pattern = re.compile(r"StartupFiles\S*")
+            
+            self.beam.filenameIncidentBeamSpectrumParams = (
+                re.search(pattern, self.beam.filenameIncidentBeamSpectrumParams).group()
             )
 
             self.beam.overallBackgroundFactor = (

--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -400,21 +400,32 @@ class GudrunFile:
             pattern = re.compile(r"StartupFiles\S*")
 
             self.instrument.detectorCalibrationFileName = (
-                re.search(pattern, self.instrument.detectorCalibrationFileName).group()
+                re.search(
+                    pattern,
+                    self.instrument.detectorCalibrationFileName
+                ).group()
             )
 
             self.instrument.groupFileName = (
-                re.search(pattern, self.instrument.groupFileName).group()
+                re.search(
+                    pattern,
+                    self.instrument.groupFileName
+                ).group()
             )
 
             self.instrument.deadtimeConstantsFileName = (
-                re.search(pattern, self.instrument.deadtimeConstantsFileName).group()
+                re.search(
+                    pattern,
+                    self.instrument.deadtimeConstantsFileName
+                ).group()
             )
 
             self.instrument.neutronScatteringParametersFile = (
-                re.search(pattern, self.instrument.neutronScatteringParametersFile).group()
+                re.search(
+                    pattern,
+                    self.instrument.neutronScatteringParametersFile
+                ).group()
             )
-
 
         except Exception as e:
             raise ParserException(
@@ -496,11 +507,15 @@ class GudrunFile:
                 firstword(self.getNextToken())
             )
 
-            # Now match it against a pattern, to resolve the path to be relative.
+            # Now match it against a pattern,
+            # to resolve the path to be relative.
             pattern = re.compile(r"StartupFiles\S*")
-            
+
             self.beam.filenameIncidentBeamSpectrumParams = (
-                re.search(pattern, self.beam.filenameIncidentBeamSpectrumParams).group()
+                re.search(
+                    pattern,
+                    self.beam.filenameIncidentBeamSpectrumParams
+                ).group()
             )
 
             self.beam.overallBackgroundFactor = (

--- a/src/gui/widgets/slots/beam_slots.py
+++ b/src/gui/widgets/slots/beam_slots.py
@@ -1,7 +1,7 @@
 from src.gudrun_classes.enums import Geometry, Instruments
 from src.gudrun_classes import config
 from PySide6.QtWidgets import QFileDialog
-
+import regex as re
 
 class BeamSlots():
 
@@ -412,7 +412,7 @@ class BeamSlots():
         if filename:
             (
                 self.widget.incidentBeamSpectrumParametersLineEdit
-            ).setText(filename)
+            ).setText(re.search(r"StartupFiles\S*", filename).group())
 
     def handleOverallBackgroundFactorChanged(self, value):
         """

--- a/src/gui/widgets/slots/beam_slots.py
+++ b/src/gui/widgets/slots/beam_slots.py
@@ -3,6 +3,7 @@ from src.gudrun_classes import config
 from PySide6.QtWidgets import QFileDialog
 import regex as re
 
+
 class BeamSlots():
 
     def __init__(self, widget, parent):
@@ -386,7 +387,12 @@ class BeamSlots():
         value : str
             The new value of the incidentBeamSpectrumParametersLineEdit.
         """
-        self.beam.filenameIncidentBeamSpectrumParams = re.search(r"StartupFiles\S*", value).group()
+        self.beam.filenameIncidentBeamSpectrumParams = (
+            re.search(
+                r"StartupFiles\S*",
+                value
+            ).group()
+        )
         if not self.widgetsRefreshing:
             self.parent.setModified()
 

--- a/src/gui/widgets/slots/beam_slots.py
+++ b/src/gui/widgets/slots/beam_slots.py
@@ -386,7 +386,7 @@ class BeamSlots():
         value : str
             The new value of the incidentBeamSpectrumParametersLineEdit.
         """
-        self.beam.filenameIncidentBeamSpectrumParams = value
+        self.beam.filenameIncidentBeamSpectrumParams = re.search(r"StartupFiles\S*", value).group()
         if not self.widgetsRefreshing:
             self.parent.setModified()
 

--- a/src/gui/widgets/slots/instrument_slots.py
+++ b/src/gui/widgets/slots/instrument_slots.py
@@ -1167,7 +1167,7 @@ class InstrumentSlots():
         filename = self.browseFile(title, dir=dir)
         if filename and not dir:
             target.setText(re.search(self.pathRegex, filename).group())
-        else:
+        elif filename:
             target.setText(filename)
 
     def browseFile(self, title, dir=False):

--- a/src/gui/widgets/slots/instrument_slots.py
+++ b/src/gui/widgets/slots/instrument_slots.py
@@ -3,7 +3,7 @@ from PySide6.QtGui import QRegularExpressionValidator
 from src.scripts.utils import spacify
 from src.gudrun_classes.enums import Scales, MergeWeights, Instruments
 from PySide6.QtWidgets import QFileDialog
-
+import regex as re
 
 class InstrumentSlots():
 
@@ -14,6 +14,7 @@ class InstrumentSlots():
 
     def setInstrument(self, instrument):
         self.instrument = instrument
+        self.pathRegex = re.compile(r"StartupFiles\S*")
         self.widgetsRefreshing = True
 
         self.widget.nameComboBox.setCurrentIndex(self.instrument.name.value)
@@ -520,7 +521,11 @@ class InstrumentSlots():
         value : str
             The new value of the detCalibrationLineEdit.
         """
-        self.instrument.detectorCalibrationFileName = text
+        self.instrument.detectorCalibrationFileName = (
+            re.search(
+                self.pathRegex, text
+            ).group()
+        )
         if not self.widgetsRefreshing:
             self.parent.setModified()
             self.parent.gudrunFile.purged = False
@@ -536,7 +541,12 @@ class InstrumentSlots():
         value : str
             The new value of the groupsFileLineEdit.
         """
-        self.instrument.groupFileName = text
+        self.instrument.groupFileName = (
+            re.search(
+                self.pathRegex,
+                text
+            ).group()
+        )
         if not self.widgetsRefreshing:
             self.parent.setModified()
             self.parent.gudrunFile.purged = False
@@ -552,7 +562,11 @@ class InstrumentSlots():
         value : str
             The new value of the deadtimeFileLineEdit.
         """
-        self.instrument.deadtimeConstantsFileName = text
+        self.instrument.deadtimeConstantsFileName = (
+            re.search(
+                self.pathRegex, text
+            ).group()
+        )
         if not self.widgetsRefreshing:
             self.parent.setModified()
 
@@ -616,7 +630,11 @@ class InstrumentSlots():
         value : str
             The new value of the neutronScatteringParamsFileLineEdit.
         """
-        self.instrument.neutronScatteringParametersFile = text
+        self.instrument.neutronScatteringParametersFile = (
+            re.search(
+                self.pathRegex, text
+            ).group()
+        )
         if not self.widgetsRefreshing:
             self.parent.setModified()
 
@@ -631,7 +649,11 @@ class InstrumentSlots():
         value : str
             The new value of the nexusDefintionFileLineEdit.
         """
-        self.instrument.nxsDefinitionFile = text
+        self.instrument.nxsDefinitionFile = (
+            re.search(
+                self.pathRegex, text
+            ).group()
+        )
         if not self.widgetsRefreshing:
             self.parent.setModified()
 
@@ -1143,7 +1165,9 @@ class InstrumentSlots():
             Defaults to false. True means accept a directory.
         """
         filename = self.browseFile(title, dir=dir)
-        if filename:
+        if filename and not dir:
+            target.setText(re.search(self.pathRegex, filename).group())
+        else:
             target.setText(filename)
 
     def browseFile(self, title, dir=False):
@@ -1176,7 +1200,10 @@ class InstrumentSlots():
                 instrumentFilesDir,
                 ""
             )
-        return filename + "/" if filename else ""
+        if dir:
+            return filename + "/" if filename else ""
+        else:
+            return filename if filename else ""
 
     def updateGroupingParameterPanel(self):
         """

--- a/src/gui/widgets/slots/instrument_slots.py
+++ b/src/gui/widgets/slots/instrument_slots.py
@@ -5,6 +5,7 @@ from src.gudrun_classes.enums import Scales, MergeWeights, Instruments
 from PySide6.QtWidgets import QFileDialog
 import regex as re
 
+
 class InstrumentSlots():
 
     def __init__(self, widget, parent):

--- a/src/gui/widgets/ui_files/mainWindow.ui
+++ b/src/gui/widgets/ui_files/mainWindow.ui
@@ -373,19 +373,6 @@
                    </property>
                   </widget>
                  </item>
-                 <item row="0" column="4">
-                  <widget class="QPushButton" name="browseConfigButton">
-                   <property name="minimumSize">
-                    <size>
-                     <width>0</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="text">
-                    <string>Browse</string>
-                   </property>
-                  </widget>
-                 </item>
                  <item row="4" column="4">
                   <widget class="QPushButton" name="browseNeutronScatteringParamsButton">
                    <property name="minimumSize">


### PR DESCRIPTION
This PR fixes up issues with absolute paths being used for configuration files within the `StartupFiles` sub-directory. Closes #248. Also, closes #247 - it turns out these handlers are there, but were not behaving as expected due to the above issue.