### PR TITLE
Modification status fix

### DIFF
--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -410,7 +410,7 @@ class GudPyMainWindow(QMainWindow):
                     del self.gudrunFile
                 self.gudrunFile = GudrunFile(path=filename)
                 self.updateWidgets()
-                self.mainWidget.setWindowTitle(self.gudrunFile.path)
+                self.mainWidget.setWindowTitle(self.gudrunFile.path + "[*]")
             except ParserException as e:
                 QMessageBox.critical(self.mainWidget, "GudPy Error", str(e))
 
@@ -879,11 +879,11 @@ class GudPyMainWindow(QMainWindow):
     def setModified(self):
         if not self.modified:
             if self.gudrunFile.path:
-                self.mainWidget.setWindowTitle(self.gudrunFile.path + " *")
+                self.mainWidget.setWindowModified(True)
                 self.modified = True
 
     def setUnModified(self):
-        self.mainWidget.setWindowTitle(self.gudrunFile.path)
+        self.mainWidget.setWindowModified(False)
         self.modified = False
 
     def setControlsEnabled(self, state):

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -410,7 +410,7 @@ class GudPyMainWindow(QMainWindow):
                     del self.gudrunFile
                 self.gudrunFile = GudrunFile(path=filename)
                 self.updateWidgets()
-                self.mainWidget.setWindowTitle(self.gudrunFile.path + "[*]")
+                self.mainWidget.setWindowTitle(self.gudrunFile.path + " [*]")
             except ParserException as e:
                 QMessageBox.critical(self.mainWidget, "GudPy Error", str(e))
 

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -113,7 +113,6 @@ class GudPyMainWindow(QMainWindow):
         """
         super(GudPyMainWindow, self).__init__()
         self.gudrunFile = None
-        self.initComponents()
         self.clipboard = None
         self.modified = False
         self.iterator = None
@@ -124,6 +123,7 @@ class GudPyMainWindow(QMainWindow):
         self.output = ""
         self.previousProcTitle = ""
         self.error = ""
+        self.initComponents()
 
     def initComponents(self):
         """
@@ -881,10 +881,12 @@ class GudPyMainWindow(QMainWindow):
             if self.gudrunFile.path:
                 self.mainWidget.setWindowModified(True)
                 self.modified = True
+                self.mainWidget.save.setEnabled(True)
 
     def setUnModified(self):
         self.mainWidget.setWindowModified(False)
         self.modified = False
+        self.mainWidget.save.setEnabled(False)
 
     def setControlsEnabled(self, state):
         self.mainWidget.instrumentPage.setEnabled(state)
@@ -909,6 +911,7 @@ class GudPyMainWindow(QMainWindow):
         self.mainWidget.viewLiveInputFile.setEnabled(state)
         self.mainWidget.save.setEnabled(
             state &
+            self.modified &
             len(self.gudrunFile.path) > 0
             if self.gudrunFile.path
             else False
@@ -935,7 +938,10 @@ class GudPyMainWindow(QMainWindow):
         self.mainWidget.checkFilesExist.setEnabled(state)
 
         self.mainWidget.viewLiveInputFile.setEnabled(state)
-        self.mainWidget.save.setEnabled(state)
+        self.mainWidget.save.setEnabled(
+            state &
+            self.modified
+        )
         self.mainWidget.saveAs.setEnabled(state)
         self.mainWidget.exportArchive.setEnabled(state)
         self.mainWidget.showPreviousOutput.setEnabled(state)


### PR DESCRIPTION
This PR attempts to fix the modification status functionality. Rather than setting the window title after a modification, we now use the `setWindowModified` method of the main window, to apply the modification status and have it persist in the title. Closes #265.
