### PR TITLE
Purge with default parameters

### DIFF
--- a/bin/configs/NIMROD.txt
+++ b/bin/configs/NIMROD.txt
@@ -34,5 +34,6 @@ StartupFiles/NIMROD/sears91_gudrun.dat          Neutron scattering parameters fi
 1          Hard group edges?
 0          Number of iterations
 0          Tweak the tweak factor(s)?
+9999        Good detector threshold
 
 }

--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -148,8 +148,8 @@ class GudrunFile:
             self.sampleBackgrounds = []
         else:
             self.instrument = None
-            self.beam = None
-            self.normalisation = None
+            self.beam = Beam()
+            self.normalisation = Normalisation()
             self.sampleBackgrounds = []
             self.parse(config=config)
         self.purged = False
@@ -391,6 +391,11 @@ class GudrunFile:
             ):
                 self.instrument.nxsDefinitionFile = (
                     firstword(self.getNextToken())
+                )
+
+            if self.config:
+                self.instrument.goodDetectorThreshold = nthint(
+                    self.getNextToken(), 0
                 )
 
             # Consume whitespace and the closing brace.
@@ -1200,7 +1205,7 @@ class GudrunFile:
         -------
         None
         """
-
+        self.config = config
         # Ensure only valid files are given.
         if not self.path:
             raise ParserException(

--- a/src/gudrun_classes/instrument.py
+++ b/src/gudrun_classes/instrument.py
@@ -154,6 +154,7 @@ class Instrument:
         self.logarithmicStepSize = 0.0
         self.hardGroupEdges = False
         self.nxsDefinitionFile = ""
+        self.goodDetectorThreshold = 0
 
     def __str__(self):
         """

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -124,7 +124,7 @@ class GudPyMainWindow(QMainWindow):
         self.output = ""
         self.previousProcTitle = ""
         self.error = ""
-        self.defaultPurge = False
+        self.warning = ""
 
     def initComponents(self):
         """
@@ -761,7 +761,6 @@ class GudPyMainWindow(QMainWindow):
     def purgeBeforeRunning(self, default=True):
         self.setControlsEnabled(False)
         if default:
-            self.defaultPurge = True
             purge_det = self.gudrunFile.purge(
                 headless=False
             )
@@ -1057,18 +1056,11 @@ class GudPyMainWindow(QMainWindow):
             if self.gudrunFile.instrument.name in detectorThresholds.keys():
                 thresh = detectorThresholds[self.gudrunFile.instrument.name]
                 if detectors < thresh:
-                    QMessageBox.warning(
-                        self.mainWidget, "GudPy Warning",
+                    self.warning = (
                         f"{detectors} detectors made it through the purge."
                         " The acceptable minimum for "
                         f"{self.gudrunFile.instrument.name.name} is {thresh}"
                     )
-            elif not self.defaultPurge:
-                QMessageBox.warning(
-                    self.mainWidget, "GudPy Warning",
-                    f"{detectors} detectors made it through the purge."
-                )
-            self.defaultPurge = False
 
     def procStarted(self):
         self.mainWidget.currentTaskLabel.setText(
@@ -1096,6 +1088,12 @@ class GudPyMainWindow(QMainWindow):
         if not self.queue.empty():
             self.makeProc(*self.queue.get())
         else:
+            if self.warning:
+                QMessageBox.warning(
+                    self.mainWidget, "GudPy Warning",
+                    self.warning
+                )
+                self.warning = ""
             self.setControlsEnabled(True)
 
     def viewInput(self):

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -124,6 +124,7 @@ class GudPyMainWindow(QMainWindow):
         self.output = ""
         self.previousProcTitle = ""
         self.error = ""
+        self.defaultPurge = False
 
     def initComponents(self):
         """
@@ -760,6 +761,7 @@ class GudPyMainWindow(QMainWindow):
     def purgeBeforeRunning(self, default=True):
         self.setControlsEnabled(False)
         if default:
+            self.defaultPurge = True
             purge_det = self.gudrunFile.purge(
                 headless=False
             )
@@ -1061,11 +1063,12 @@ class GudPyMainWindow(QMainWindow):
                         " The acceptable minimum for "
                         f"{self.gudrunFile.instrument.name.name} is {thresh}"
                     )
-            else:
+            elif not self.defaultPurge:
                 QMessageBox.warning(
                     self.mainWidget, "GudPy Warning",
                     f"{detectors} detectors made it through the purge."
                 )
+            self.defaultPurge = False
 
     def procStarted(self):
         self.mainWidget.currentTaskLabel.setText(

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -1061,6 +1061,7 @@ class GudPyMainWindow(QMainWindow):
                         " The acceptable minimum for "
                         f"{self.gudrunFile.instrument.name.name} is {thresh}"
                     )
+            self.mainWidget.goodDetectorsLabel.setText(f"Number of Good Detectors: {detectors}")
 
     def procStarted(self):
         self.mainWidget.currentTaskLabel.setText(

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -1061,7 +1061,9 @@ class GudPyMainWindow(QMainWindow):
                         " The acceptable minimum for "
                         f"{self.gudrunFile.instrument.name.name} is {thresh}"
                     )
-            self.mainWidget.goodDetectorsLabel.setText(f"Number of Good Detectors: {detectors}")
+            self.mainWidget.goodDetectorsLabel.setText(
+                f"Number of Good Detectors: {detectors}"
+            )
 
     def procStarted(self):
         self.mainWidget.currentTaskLabel.setText(

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -43,7 +43,7 @@ from src.gui.widgets.gudpy_charts import (
   GudPyChart, PlotModes, GudPyChartView
 )
 
-from src.gudrun_classes.enums import Geometry, Instruments
+from src.gudrun_classes.enums import Geometry
 from src.gui.widgets.slots.instrument_slots import InstrumentSlots
 from src.gui.widgets.slots.beam_slots import BeamSlots
 from src.gui.widgets.slots.component_slots import ComponentSlots

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -1055,19 +1055,14 @@ class GudPyMainWindow(QMainWindow):
             progress if progress <= 100 else 100
         )
 
-        detectorThresholds = {
-            Instruments.NIMROD: 2150
-        }
-
         if finished:
-            if self.gudrunFile.instrument.name in detectorThresholds.keys():
-                thresh = detectorThresholds[self.gudrunFile.instrument.name]
-                if detectors < thresh:
-                    self.warning = (
-                        f"{detectors} detectors made it through the purge."
-                        " The acceptable minimum for "
-                        f"{self.gudrunFile.instrument.name.name} is {thresh}"
-                    )
+            thresh = self.gudrunFile.instrument.goodDetectorThreshold
+            if thresh and detectors < thresh:
+                self.warning = (
+                    f"{detectors} detectors made it through the purge."
+                    " The acceptable minimum for "
+                    f"{self.gudrunFile.instrument.name.name} is {thresh}"
+                )
             self.mainWidget.goodDetectorsLabel.setText(
                 f"Number of Good Detectors: {detectors}"
             )

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -43,7 +43,7 @@ from src.gui.widgets.gudpy_charts import (
   GudPyChart, PlotModes, GudPyChartView
 )
 
-from src.gudrun_classes.enums import Geometry
+from src.gudrun_classes.enums import Geometry, Instruments
 from src.gui.widgets.slots.instrument_slots import InstrumentSlots
 from src.gui.widgets.slots.beam_slots import BeamSlots
 from src.gui.widgets.slots.component_slots import ComponentSlots
@@ -1046,11 +1046,26 @@ class GudPyMainWindow(QMainWindow):
         self.mainWidget.progressBar.setValue(
             progress if progress <= 100 else 100
         )
+
+        detectorThresholds = {
+            Instruments.NIMROD: 2150
+        }
+
         if finished:
-            QMessageBox.warning(
-                self.mainWidget, "GudPy Warning",
-                f"{detectors} detectors made it through the purge."
-            )
+            if self.gudrunFile.instrument.name in detectorThresholds.keys():
+                thresh = detectorThresholds[self.gudrunFile.instrument.name]
+                if detectors < thresh:
+                    QMessageBox.warning(
+                        self.mainWidget, "GudPy Warning",
+                        f"{detectors} detectors made it through the purge."
+                        " The acceptable minimum for "
+                        f"{self.gudrunFile.instrument.name.name} is {thresh}"
+                    )
+            else:
+                QMessageBox.warning(
+                    self.mainWidget, "GudPy Warning",
+                    f"{detectors} detectors made it through the purge."
+                )
 
     def procStarted(self):
         self.mainWidget.currentTaskLabel.setText(

--- a/src/gui/widgets/ui_files/mainWindow.ui
+++ b/src/gui/widgets/ui_files/mainWindow.ui
@@ -1107,7 +1107,7 @@
                     </sizepolicy>
                    </property>
                    <property name="currentIndex">
-                    <number>0</number>
+                    <number>1</number>
                    </property>
                    <widget class="QWidget" name="DataBinningTab">
                     <attribute name="title">
@@ -2263,6 +2263,13 @@
                     </spacer>
                    </item>
                   </layout>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="goodDetectorsLabel">
+                   <property name="text">
+                    <string>Number of Good Detectors: </string>
+                   </property>
+                  </widget>
                  </item>
                 </layout>
                </widget>

--- a/tests/test_gudpy_io.py
+++ b/tests/test_gudpy_io.py
@@ -83,7 +83,8 @@ class TestGudPyIO(TestCase):
             "startupFileFolder": "StartupFiles",
             "logarithmicStepSize": 0.04,
             "hardGroupEdges": True,
-            "nxsDefinitionFile": ""
+            "nxsDefinitionFile": "",
+            "goodDetectorThreshold": 0
         }
 
         self.expectedBeam = {
@@ -932,7 +933,8 @@ class TestGudPyIO(TestCase):
         expectedInstrument.pop("wavelengthStep", None)
         expectedInstrument.pop("useLogarithmicBinning", None)
         expectedInstrument.pop("nxsDefinitionFile", None)
-        expectedInstrument.pop("groupingParameterPanel")
+        expectedInstrument.pop("groupingParameterPanel", None)
+        expectedInstrument.pop("goodDetectorThreshold", None)
         for i in range(len(expectedInstrument.keys())):
 
             badInstrument = str(self.goodInstrument).split("\n")
@@ -964,6 +966,7 @@ class TestGudPyIO(TestCase):
         expectedInstrument.pop("useLogarithmicBinning", None)
         expectedInstrument.pop("nxsDefinitionFile", None)
         expectedInstrument.pop("groupingParameterPanel", None)
+        expectedInstrument.pop("goodDetectorThreshold", None)
         for i in range(50):
 
             key = random.choice(list(expectedInstrument))


### PR DESCRIPTION
This PR updates the way the results of `purge_det` are indicated. Now, a warning is produced, currently for `NIMROD` only, if the number of detectors that made it through the purge is below an acceptable threshold. Also, the number of good detectors is indicated on the `Instrument` page. This closes #263.