### PR TITLE
Save with suffix

### DIFF
--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -558,7 +558,7 @@ class GudPyMainWindow(QMainWindow):
         Saves the current state of the input file as...
         """
         filename, _ = QFileDialog.getSaveFileName(
-            self, "Save input file as..", "."
+            self, "Save input file as..", ".", "(*.txt)"
         )
         if filename:
             self.gudrunFile.instrument.GudrunInputFileDir = (


### PR DESCRIPTION
PR to apply the `.txt` suffix to the selected filename when using the `Save As..` option. This is to ensure that GudPy picks the file up when trying to load it in future. Closes #279.