### PR TITLE
Gudrun GUI Compatibility

### DIFF
--- a/src/gudrun_classes/beam.py
+++ b/src/gudrun_classes/beam.py
@@ -93,16 +93,16 @@ class Beam:
         absorptionAndMSLine = (
             f'{self.stepSizeAbsorption}{config.spc2}'
             f'{self.stepSizeMS}{config.spc2}'
-            f'{self.noSlices}{config.spc2}'
+            f'{self.noSlices}'
             f'{config.spc5}'
-            f'Step size for absorption and m.s. calculation of no. of slices\n'
+            f'Step size for absorption and m.s. calculation and no. of slices\n'
         )
 
         incidentBeamLine = (
             f'{self.incidentBeamLeftEdge}{config.spc2}'
             f'{self.incidentBeamRightEdge}{config.spc2}'
             f'{self.incidentBeamBottomEdge}{config.spc2}'
-            f'{self.incidentBeamTopEdge}{config.spc2}'
+            f'{self.incidentBeamTopEdge}'
             f'{config.spc5}'
             f'Incident beam edges relative to centre of sample [cm]\n'
         )
@@ -112,7 +112,7 @@ class Beam:
             f'{self.scatteredBeamBottomEdge}{config.spc2}'
             f'{self.scatteredBeamTopEdge}'
             f'{config.spc5}'
-            f'Scattered beam edges relateive to centre of samples [cm]\n'
+            f'Scattered beam edges relative to centre of sample [cm]\n'
         )
 
         return (
@@ -121,7 +121,7 @@ class Beam:
             f'Sample geometry\n'
             f'{len(self.beamProfileValues)}{config.spc5}'
             f'Number of beam profile values\n'
-            f'{spacify(self.beamProfileValues, num_spaces=2)}{config.spc5}'
+            f'{spacify(self.beamProfileValues, num_spaces=2)}{config.spc2}{config.spc5}'
             f'Beam profile values (Maximum of 50 allowed currently)\n'
             f'{absorptionAndMSLine}'
             f'{self.angularStepForCorrections}{config.spc5}'

--- a/src/gudrun_classes/beam.py
+++ b/src/gudrun_classes/beam.py
@@ -1,6 +1,6 @@
 from src.scripts.utils import spacify
 from src.gudrun_classes.enums import Geometry
-
+from src.gudrun_classes import config
 
 class Beam:
     """
@@ -89,53 +89,52 @@ class Beam:
         string : str
             String representation of Beam.
         """
-        TAB = "          "
+
+        absorptionAndMSLine = (
+            f'{self.stepSizeAbsorption}{config.spc2}'
+            f'{self.stepSizeMS}{config.spc2}'
+            f'{self.noSlices}{config.spc2}'
+            f'{config.spc5}'
+            f'Step size for absorption and m.s. calculation of no. of slices\n'
+        )
 
         incidentBeamLine = (
-            f'{self.incidentBeamLeftEdge} '
-            f'{self.incidentBeamRightEdge} '
-            f'{self.incidentBeamBottomEdge} '
-            f'{self.incidentBeamTopEdge}'
-            f'{TAB}'
+            f'{self.incidentBeamLeftEdge}{config.spc2}'
+            f'{self.incidentBeamRightEdge}{config.spc2}'
+            f'{self.incidentBeamBottomEdge}{config.spc2}'
+            f'{self.incidentBeamTopEdge}{config.spc2}'
+            f'{config.spc5}'
             f'Incident beam edges relative to centre of sample [cm]\n'
         )
         scatteredBeamLine = (
-            f'{self.scatteredBeamLeftEdge} '
-            f'{self.scatteredBeamRightEdge} '
-            f'{self.scatteredBeamBottomEdge} '
+            f'{self.scatteredBeamLeftEdge}{config.spc2}'
+            f'{self.scatteredBeamRightEdge}{config.spc2}'
+            f'{self.scatteredBeamBottomEdge}{config.spc2}'
             f'{self.scatteredBeamTopEdge}'
-            f'{TAB}'
+            f'{config.spc5}'
             f'Scattered beam edges relateive to centre of samples [cm]\n'
-        )
-
-        absorptionAndMSLine = (
-            f'{self.stepSizeAbsorption} '
-            f'{self.stepSizeMS} '
-            f'{self.noSlices}'
-            f'{TAB}'
-            f'Step size for absorption and m.s. calculation of no. of slices\n'
         )
 
         return (
 
-            f'{Geometry(self.sampleGeometry.value).name}{TAB}'
+            f'{Geometry(self.sampleGeometry.value).name}{config.spc5}'
             f'Sample geometry\n'
-            f'{len(self.beamProfileValues)}{TAB}'
+            f'{len(self.beamProfileValues)}{config.spc5}'
             f'Number of beam profile values\n'
-            f'{spacify(self.beamProfileValues)}{TAB}'
+            f'{spacify(self.beamProfileValues, num_spaces=2)}{config.spc5}'
             f'Beam profile values (Maximum of 50 allowed currently)\n'
             f'{absorptionAndMSLine}'
-            f'{self.angularStepForCorrections}{TAB}'
+            f'{self.angularStepForCorrections}{config.spc5}'
             f'Angular step for corrections [deg.]\n'
             f'{incidentBeamLine}'
             f'{scatteredBeamLine}'
-            f'{self.filenameIncidentBeamSpectrumParams}{TAB}'
+            f'{self.filenameIncidentBeamSpectrumParams}{config.spc5}'
             f'Filename containing incident beam spectrum parameters\n'
-            f'{self.overallBackgroundFactor}{TAB}'
+            f'{self.overallBackgroundFactor}{config.spc5}'
             f'Overall background factor\n'
-            f'{self.sampleDependantBackgroundFactor}{TAB}'
+            f'{self.sampleDependantBackgroundFactor}{config.spc5}'
             f'Sample dependent background factor\n'
-            f'{self.shieldingAttenuationCoefficient}{TAB}'
+            f'{self.shieldingAttenuationCoefficient}{config.spc5}'
             f'Shielding attenuation coefficient [per m per \u212b]'
 
         )

--- a/src/gudrun_classes/composition.py
+++ b/src/gudrun_classes/composition.py
@@ -2,6 +2,7 @@ from src.gudrun_classes.element import Element
 from src.gudrun_classes.isotopes import Sears91
 from src.gudrun_classes.exception import ChemicalFormulaParserException
 from src.gudrun_classes.mass_data import massData
+from src.gudrun_classes import config
 import re
 import math
 
@@ -199,7 +200,7 @@ class Composition():
         string = ""
         for el in self.elements:
             string += (
-                str(el) + "        " +
+                str(el) + config.spc5 + config.spc2 +
                 self.type_ + " atomic composition\n"
             )
 

--- a/src/gudrun_classes/composition.py
+++ b/src/gudrun_classes/composition.py
@@ -200,8 +200,8 @@ class Composition():
         string = ""
         for el in self.elements:
             string += (
-                str(el) + config.spc5 + config.spc2 +
-                self.type_ + " atomic composition\n"
+                str(el) + config.spc5 +
+                "Composition\n"
             )
 
         return string.rstrip()

--- a/src/gudrun_classes/config.py
+++ b/src/gudrun_classes/config.py
@@ -1,6 +1,9 @@
 from src.gudrun_classes.composition import Components
 from src.gudrun_classes.enums import Geometry
 
+spc2 = "  "
+spc5 = "          "
+
 geometry = Geometry.FLATPLATE
 NUM_GUDPY_CORE_OBJECTS = 4
 USE_USER_DEFINED_COMPONENTS = False

--- a/src/gudrun_classes/container.py
+++ b/src/gudrun_classes/container.py
@@ -168,7 +168,7 @@ class Container:
             f'{dataFilesLines}'
             f'{str(self.composition)}{compositionSuffix}'
             f'*{config.spc2}0{config.spc2}0{config.spc5}* 0 0 to specify end of composition input\n'
-            f'{Geometry(self.geometry.value).name}{config.spc5}'
+            f'SameAsBeam{config.spc5}'
             f'Geometry\n'
             f'{geometryLines}'
             f'{densityLine}'

--- a/src/gudrun_classes/container.py
+++ b/src/gudrun_classes/container.py
@@ -106,13 +106,11 @@ class Container:
             String representation of Container.
         """
 
-        TAB = "          "
-
         nameLine = (
-            f"CONTAINER {self.name}{TAB}"
+            f"CONTAINER {self.name}{config.spc5}"
             if self.name != "CONTAINER"
             else
-            f"CONTAINER{TAB}"
+            f"CONTAINER{config.spc5}"
         )
 
         dataFilesLines = (
@@ -132,25 +130,24 @@ class Container:
         compositionSuffix = "" if str(self.composition) == "" else "\n"
 
         geometryLines = (
-            f'{self.upstreamThickness}  {self.downstreamThickness}{TAB}'
-            f'Upstream and downstream thickness [cm]\n'
-            f'{self.angleOfRotation}  {self.sampleWidth}{TAB}'
+            f'{self.upstreamThickness}{config.spc2}{self.downstreamThickness}{config.spc5}'
+            f'Upstream and downstream thicknesses [cm]\n'
+            f'{self.angleOfRotation}{config.spc2}{self.sampleWidth}{config.spc5}'
             f'Angle of rotation and sample width (cm)\n'
-            if
-            (
+            if (
                 self.geometry == Geometry.SameAsBeam
                 and config.geometry == Geometry.FLATPLATE
             )
             or self.geometry == Geometry.FLATPLATE
             else
-            f'{self.innerRadius}  {self.outerRadius}{TAB}'
+            f'{self.innerRadius}{config.spc2}{self.outerRadius}{config.spc5}'
             f'Inner and outer radii [cm]\n'
-            f'{self.sampleHeight}{TAB}'
+            f'{self.sampleHeight}{config.spc5}'
             f'Sample height (cm)\n'
         )
 
         densityLine = (
-            f'{density}{TAB}'
+            f'{density}{config.spc5}'
             f'Density {units}?\n'
         )
 
@@ -158,30 +155,29 @@ class Container:
             CrossSectionSource(self.totalCrossSectionSource.value).name
         )
         crossSectionLine = (
-            f"{crossSectionSource}{TAB}"
+            f"{crossSectionSource}{config.spc5}"
             if self.totalCrossSectionSource != CrossSectionSource.FILE
             else
-            f"{self.crossSectionFilename}{TAB}"
+            f"{self.crossSectionFilename}{config.spc5}"
         )
 
         return (
             f'{nameLine}{{\n\n'
-            f'{len(self.dataFiles)}  {self.periodNumber}{TAB}'
+            f'{len(self.dataFiles)}{config.spc2}{self.periodNumber}{config.spc5}'
             f'Number of files and period number\n'
             f'{dataFilesLines}'
             f'{str(self.composition)}{compositionSuffix}'
-            f'*  0  0{TAB}'
-            f'* 0 0 to specify end of composition input\n'
-            f'{Geometry(self.geometry.value).name}{TAB}'
+            f'*{config.spc2}0{config.spc2}0{config.spc5}* 0 0 to specify end of composition input\n'
+            f'{Geometry(self.geometry.value).name}{config.spc5}'
             f'Geometry\n'
             f'{geometryLines}'
             f'{densityLine}'
             f'{crossSectionLine}'
             f'Total cross section source\n'
-            f'{self.tweakFactor}{TAB}'
+            f'{self.tweakFactor}{config.spc5}'
             f'Tweak factor\n'
-            f'{self.scatteringFraction}  {self.attenuationCoefficient}'
-            f'{TAB}'
+            f'{self.scatteringFraction}{config.spc2}{self.attenuationCoefficient}'
+            f'{config.spc5}'
             f'Sample environment scattering fraction '
             f'and attenuation coefficient [per \u212b]\n'
             f'\n}}\n'

--- a/src/gudrun_classes/data_files.py
+++ b/src/gudrun_classes/data_files.py
@@ -1,3 +1,4 @@
+from src.gudrun_classes import config
 class DataFiles:
     """
     Class to represent a set of data files belonging to an object.
@@ -41,7 +42,7 @@ class DataFiles:
             String representation of DataFiles.
         """
         self.str = [
-            df + "        " + self.name + " data files"
+            df + config.spc5 + self.name + " data files"
             for df in self.dataFiles
             ]
         return """\n""".join(self.str)

--- a/src/gudrun_classes/element.py
+++ b/src/gudrun_classes/element.py
@@ -1,3 +1,4 @@
+from src.gudrun_classes import config
 class Element:
     """
     Class to represent an Element.
@@ -48,9 +49,9 @@ class Element:
         """
         return (
             self.atomicSymbol
-            + "  "
+            + config.spc2
             + str(self.massNo)
-            + "  "
+            + config.spc2
             + str(self.abundance)
         )
 

--- a/src/gudrun_classes/gud_file.py
+++ b/src/gudrun_classes/gud_file.py
@@ -94,8 +94,7 @@ class GudFile:
         fname = os.path.basename(self.path)
         ref_fname = "gudpy_{}".format(fname)
         dir = os.path.dirname(os.path.abspath(self.path))
-        self.outpath = "{}/{}".format(dir, ref_fname)
-
+        self.outpath = f"{dir}{os.path.sep}{ref_fname}"
         self.name = ""
         self.title = ""
         self.author = ""

--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -1354,14 +1354,19 @@ class GudrunFile:
         sampleBackgrounds = "\n".join(
             [str(x) for x in self.sampleBackgrounds]
         ).rstrip()
-        footer = "\n\n\nEND\n1\nDate and Time last written:  {}\nN".format(
-            time.strftime("%Y%m%d %H:%M:%S")
+        footer= (
+            f"\n\n\nEND{config.spc5}"
+            f"\n1\nDate and time last written:  "
+            f"{time.strftime('%Y%m%d %H:%M:%S')}{config.spc5}"
+            f"\nN-1"
         )
+
         components = (
             f"\n\nCOMPONENTS:\n{str(config.components)}"
             if len(config.components.components)
             else ""
         )
+
         return (
             header
             + instrument

--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -1337,16 +1337,16 @@ class GudrunFile:
         """
 
         LINEBREAK = "\n\n"
-        header = f"'  '  '        '  '{os.path.sep}'" + LINEBREAK
+        header = f"'{config.spc2}'{config.spc2}'{config.spc5}'{config.spc2}'{os.path.sep}'" + LINEBREAK
         instrument = (
-            "INSTRUMENT          {\n\n"
+            f"INSTRUMENT{config.spc5}{{\n\n"
             + str(self.instrument)
             + LINEBREAK
             + "}"
         )
-        beam = "BEAM          {\n\n" + str(self.beam) + LINEBREAK + "}"
+        beam = f"BEAM{config.spc5}{{\n\n" + str(self.beam) + LINEBREAK + "}"
         normalisation = (
-            "NORMALISATION          {\n\n"
+            f"NORMALISATION{config.spc5}{{\n\n"
             + str(self.normalisation)
             + LINEBREAK
             + "}"

--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -1337,7 +1337,7 @@ class GudrunFile:
         """
 
         LINEBREAK = "\n\n"
-        header = "'  '  '        '  '/'" + LINEBREAK
+        header = f"'  '  '        '  '{os.path.sep}'" + LINEBREAK
         instrument = (
             "INSTRUMENT          {\n\n"
             + str(self.instrument)

--- a/src/gudrun_classes/instrument.py
+++ b/src/gudrun_classes/instrument.py
@@ -1,5 +1,6 @@
 from src.scripts.utils import spacify, numifyBool, bjoin
 from src.gudrun_classes.enums import MergeWeights, Scales, Instruments
+from src.gudrun_classes import config
 import os
 import sys
 
@@ -169,39 +170,38 @@ class Instrument:
         string : str
             String representation of Instrument.
         """
-        TAB = "          "
 
         wavelengthLineA = spacify(
             self.wavelengthRangeForMonitorNormalisation,
-            num_spaces=2
+            num_spaces=len(config.spc2)
         )
 
         channelNosLine = spacify(
             self.channelNosSpikeAnalysis,
-            num_spaces=2
+            num_spaces=len(config.spc2)
         )
 
         wavelengthLineB = (
             f'{self.wavelengthMin}'
-            f'  {self.wavelengthMax}'
-            f'  {self.wavelengthStep}'
+            f'{config.spc2}{self.wavelengthMax}'
+            f'{config.spc2}{self.wavelengthStep}'
         )
 
         XScaleLine = (
-            f'{self.XMin}  {self.XMax}  -0.01'
+            f'{self.XMin}{config.spc2}{self.XMax}{config.spc2}-0.01'
             if self.useLogarithmicBinning
             else
-            f'{self.XMin}  {self.XMax}  {self.XStep}'
+            f'{self.XMin}{config.spc2}{self.XMax}{config.spc2}{self.XStep}'
         )
 
         joined = bjoin(
             self.groupingParameterPanel,
-            " Group, Xmin, Xmax, Background factor\n",
+            f"{config.spc5}Group, Xmin, Xmax, Background factor\n",
             sameseps=True
         )
         groupingParameterPanelLine = (
             f'{joined}'
-            f'0  0  0  0{TAB}0 0 0 0 to end input of specified values\n'
+            f'0{config.spc2}0{config.spc2}0{config.spc2}0{config.spc5}0 0 0 0 to end input of specified values\n'
         )
 
         if self.mergeWeights == MergeWeights.NONE:
@@ -212,87 +212,90 @@ class Instrument:
             mergeBy = "By channel?"
 
         mergeWeightsLine = (
-            f'{self.mergeWeights.value}{TAB}'
+            f'{self.mergeWeights.value}{config.spc5}'
             f'{mergeBy}\n'
         )
 
         scaleSelectionLine = (
-            f'{self.scaleSelection.value}        '
+            f'{self.scaleSelection.value}{config.spc5}'
             f'Scale selection: 1 = Q, 2 = d-space,'
             f' 3 = wavelength, 4 = energy, 5 = TOF\n'
         )
 
         nexusDefinitionLine = (
-            f'\n{self.nxsDefinitionFile}{TAB}'
-            f'NeXus definition file\n'
-            if self.nxsDefinitionFile
+            f'\n{self.nxsDefinitionFile}{config.spc5}'
+            f'NeXus definition file'
+            if (
+                self.dataFileType == "nxs" or
+                self.dataFileType == "NXS"
+            )
             else
             ""
         )
 
         return (
-            f'{Instruments(self.name.value).name}{TAB}'
+            f'{Instruments(self.name.value).name}{config.spc5}'
             f'Instrument name\n'
-            f'{self.GudrunInputFileDir}{TAB}'
+            f'{self.GudrunInputFileDir}{config.spc5}'
             f'Gudrun input file directory:\n'
-            f'{self.dataFileDir}{TAB}'
+            f'{self.dataFileDir}{config.spc5}'
             f'Data file directory\n'
-            f'{self.dataFileType}{TAB}'
+            f'{self.dataFileType}{config.spc5}'
             f'Data file type\n'
-            f'{self.detectorCalibrationFileName}{TAB}'
+            f'{self.detectorCalibrationFileName}{config.spc5}'
             f'Detector calibration file name\n'
-            f'{self.columnNoPhiVals}{TAB}'
+            f'{self.columnNoPhiVals}{config.spc5}'
             f'User table column number for phi values\n'
-            f'{self.groupFileName}{TAB}'
+            f'{self.groupFileName}{config.spc5}'
             f'Groups file name\n'
-            f'{self.deadtimeConstantsFileName}{TAB}'
+            f'{self.deadtimeConstantsFileName}{config.spc5}'
             f'Deadtime constants file name\n'
-            f'{spacify(self.spectrumNumbersForIncidentBeamMonitor)}{TAB}'
+            f'{spacify(self.spectrumNumbersForIncidentBeamMonitor)}{config.spc5}'
             f'Spectrum number(s) for incident beam monitor\n'
-            f'{wavelengthLineA}{TAB}'
+            f'{wavelengthLineA}{config.spc5}'
             f'Wavelength range [\u212b] for monitor normalisation\n'
-            f'{spacify(self.spectrumNumbersForTransmissionMonitor)}{TAB}'
+            f'{spacify(self.spectrumNumbersForTransmissionMonitor)}{config.spc5}'
             f'Spectrum number(s) for transmission monitor\n'
-            f'{self.incidentMonitorQuietCountConst}{TAB}'
+            f'{self.incidentMonitorQuietCountConst}{config.spc5}'
             f'Incident monitor quiet count constant\n'
-            f'{self.transmissionMonitorQuietCountConst}{TAB}'
+            f'{self.transmissionMonitorQuietCountConst}{config.spc5}'
             f'Transmission monitor quiet count constant\n'
-            f'{channelNosLine}{TAB}'
+            f'{channelNosLine}{config.spc5}'
             f'Channel numbers for spike analysis\n'
-            f'{self.spikeAnalysisAcceptanceFactor}{TAB}'
+            f'{self.spikeAnalysisAcceptanceFactor}{config.spc5}'
             f'Spike analysis acceptance factor\n'
-            f'{wavelengthLineB}{TAB}'
+            f'{wavelengthLineB}{config.spc5}'
             f'Wavelength range to use [\u212b] and step size\n'
-            f'{self.NoSmoothsOnMonitor}{TAB}'
+            f'{self.NoSmoothsOnMonitor}{config.spc2}{config.spc5}'
             f'No. of smooths on monitor\n'
-            f'{XScaleLine}{TAB}'
+            f'{XScaleLine}{config.spc5}'
             f'Min, Max and step in x-scale (-ve for logarithmic binning)\n'
             f'{groupingParameterPanelLine}'
-            f'{self.groupsAcceptanceFactor}{TAB}'
+            f'{self.groupsAcceptanceFactor}{config.spc5}'
             f'Groups acceptance factor\n'
-            f'{self.mergePower}{TAB}'
+            f'{self.mergePower}{config.spc5}'
             f'Merge power\n'
-            f'{numifyBool(self.subSingleAtomScattering)}{TAB}'
+            f'{numifyBool(self.subSingleAtomScattering)}{config.spc5}'
             f'Substract single atom scattering?\n'
             f'{mergeWeightsLine}'
-            f'{self.incidentFlightPath}{TAB}'
+            f'{self.incidentFlightPath}{config.spc5}'
             f'Incident flight path [m]\n'
-            f'{self.spectrumNumberForOutputDiagnosticFiles}{TAB}'
+            f'{self.spectrumNumberForOutputDiagnosticFiles}{config.spc5}'
             f'Spectrum number to output diagnostic files\n'
-            f'{self.neutronScatteringParametersFile}{TAB}'
+            f'{self.neutronScatteringParametersFile}{config.spc5}'
             f'Neutron scattering parameters file\n'
             f'{scaleSelectionLine}'
-            f'{numifyBool(self.subWavelengthBinnedData)}{TAB}'
+            f'{numifyBool(self.subWavelengthBinnedData)}{config.spc5}'
             f'Subtract wavelength-binned data?\n'
-            f'{self.GudrunStartFolder}{TAB}'
+            f'{self.GudrunStartFolder}{config.spc5}'
             f'Folder where Gudrun started\n'
-            f'{self.startupFileFolder}{TAB}'
+            f'{self.startupFileFolder}{config.spc5}'
             f'Folder containing the startup file\n'
-            f'{self.logarithmicStepSize}{TAB}'
+            f'{self.logarithmicStepSize}{config.spc5}'
             f'Logarithmic step size\n'
-            f'{numifyBool(self.hardGroupEdges)}{TAB}'
+            f'{numifyBool(self.hardGroupEdges)}{config.spc5}'
             f'Hard group edges?'
-            f'{nexusDefinitionLine}'
-            f'\n0{TAB}Number of iterations'
-            f'\n0{TAB}Tweak the tweak factor(s)?'
+            f'{nexusDefinitionLine}\n'
+            f'0{config.spc5}Number of iterations\n'
+            f'0{config.spc5}Tweak the tweak factor(s)?'
         )

--- a/src/gudrun_classes/instrument.py
+++ b/src/gudrun_classes/instrument.py
@@ -293,6 +293,6 @@ class Instrument:
             f'{numifyBool(self.hardGroupEdges)}{TAB}'
             f'Hard group edges?'
             f'{nexusDefinitionLine}'
-            f'0{TAB}Number of iterations'
-            f'0{TAB}Tweak the tweak factor(s)?'
+            f'\n0{TAB}Number of iterations'
+            f'\n0{TAB}Tweak the tweak factor(s)?'
         )

--- a/src/gudrun_classes/instrument.py
+++ b/src/gudrun_classes/instrument.py
@@ -276,7 +276,7 @@ class Instrument:
             f'{self.mergePower}{config.spc5}'
             f'Merge power\n'
             f'{numifyBool(self.subSingleAtomScattering)}{config.spc5}'
-            f'Substract single atom scattering?\n'
+            f'Subtract single atom scattering?\n'
             f'{mergeWeightsLine}'
             f'{self.incidentFlightPath}{config.spc5}'
             f'Incident flight path [m]\n'

--- a/src/gudrun_classes/normalisation.py
+++ b/src/gudrun_classes/normalisation.py
@@ -109,7 +109,6 @@ class Normalisation:
         string : str
             String representation of Normalisation.
         """
-        TAB = "          "
 
         dataFilesLineA = (
             f'{str(self.dataFiles)}\n'
@@ -128,9 +127,9 @@ class Normalisation:
         compositionSuffix = "" if str(self.composition) == "" else "\n"
 
         geometryLines = (
-            f'{self.upstreamThickness}  {self.downstreamThickness}{TAB}'
+            f'{self.upstreamThickness}{config.spc2}{self.downstreamThickness}{config.spc5}{config.spc2}'
             f'Upstream and downstream thickness [cm]\n'
-            f'{self.angleOfRotation}  {self.sampleWidth}{TAB}'
+            f'{self.angleOfRotation}{config.spc2}{self.sampleWidth}{config.spc5}'
             f'Angle of rotation and sample width (cm)\n'
             if (
                 (
@@ -139,9 +138,9 @@ class Normalisation:
                 )
                 or self.geometry == Geometry.FLATPLATE)
             else
-            f'{self.innerRadius}  {self.outerRadius}{TAB}'
+            f'{self.innerRadius}{config.spc2}{self.outerRadius}{config.spc5}'
             f'Inner and outer radii [cm]\n'
-            f'{self.sampleHeight}{TAB}'
+            f'{self.sampleHeight}{config.spc5}'
             f'Sample height (cm)\n'
         )
 
@@ -153,7 +152,7 @@ class Normalisation:
             density = self.density
 
         densityLine = (
-            f'{density}{TAB}'
+            f'{density}{config.spc5}'
             f'Density {units}?\n'
         )
 
@@ -161,40 +160,40 @@ class Normalisation:
             CrossSectionSource(self.totalCrossSectionSource.value).name
         )
         crossSectionLine = (
-            f"{crossSectionSource}{TAB}"
+            f"{crossSectionSource}{config.spc5}"
             if self.totalCrossSectionSource != CrossSectionSource.FILE
             else
-            f"{self.crossSectionFilename}{TAB}"
+            f"{self.crossSectionFilename}{config.spc5}"
         )
 
         if not self.normalisationDifferentialCrossSectionFile:
             self.normalisationDifferentialCrossSectionFile = "*"
 
         return (
-            f'{len(self.dataFiles)}  {self.periodNumber}{TAB}'
+            f'{len(self.dataFiles)}{config.spc2}{self.periodNumber}{config.spc5}'
             f'Number of  files and period number\n'
             f'{dataFilesLineA}'
-            f'{len(self.dataFilesBg)}  {self.periodNumberBg}{TAB}'
+            f'{len(self.dataFilesBg)}{config.spc2}{self.periodNumberBg}{config.spc5}'
             f'Number of  files and period number\n'
             f'{dataFilesLineB}'
-            f'{numifyBool(self.forceCalculationOfCorrections)}{TAB}'
+            f'{numifyBool(self.forceCalculationOfCorrections)}{config.spc5}'
             f'Force calculation of corrections?\n'
             f'{str(self.composition)}{compositionSuffix}'
-            f'*  0  0{TAB}* 0 0 to specify end of composition input\n'
-            f'{Geometry(self.geometry.value).name}{TAB}'
+            f'*{config.spc2}0{config.spc2}0{config.spc5}* 0 0 to specify end of composition input\n'
+            f'{Geometry(self.geometry.value).name}{config.spc5}'
             f'Geometry\n'
             f'{geometryLines}'
             f'{densityLine}'
-            f'{self.tempForNormalisationPC}{TAB}'
+            f'{self.tempForNormalisationPC}{config.spc5}'
             f'Temperature for normalisation Placzek correction\n'
             f'{crossSectionLine}'
             f'Total cross section source\n'
-            f'{self.normalisationDifferentialCrossSectionFile}{TAB}'
+            f'{self.normalisationDifferentialCrossSectionFile}{config.spc5}'
             f'Normalisation differential cross section filename\n'
-            f'{self.lowerLimitSmoothedNormalisation}{TAB}'
+            f'{self.lowerLimitSmoothedNormalisation}{config.spc5}'
             f'Lower limit on smoothed normalisation\n'
-            f'{self.normalisationDegreeSmoothing}{TAB}'
+            f'{self.normalisationDegreeSmoothing}{config.spc5}'
             f'Normalisation degree of smoothing\n'
-            f'{self.minNormalisationSignalBR}{TAB}'
+            f'{self.minNormalisationSignalBR}{config.spc5}'
             f'Minimum normalisation signal to background ratio'
         )

--- a/src/gudrun_classes/normalisation.py
+++ b/src/gudrun_classes/normalisation.py
@@ -167,6 +167,9 @@ class Normalisation:
             f"{self.crossSectionFilename}{TAB}"
         )
 
+        if not self.normalisationDifferentialCrossSectionFile:
+            self.normalisationDifferentialCrossSectionFile = "*"
+
         return (
             f'{len(self.dataFiles)}  {self.periodNumber}{TAB}'
             f'Number of  files and period number\n'

--- a/src/gudrun_classes/normalisation.py
+++ b/src/gudrun_classes/normalisation.py
@@ -126,8 +126,15 @@ class Normalisation:
 
         compositionSuffix = "" if str(self.composition) == "" else "\n"
 
+
+        geometryLine = (
+            f'SameAsBeam{config.spc5}Geometry\n'
+            if self.geometry == Geometry.SameAsBeam
+            else
+            f'{Geometry(self.geometry.value).name}{config.spc5}Geometry\n'
+        )
         geometryLines = (
-            f'{self.upstreamThickness}{config.spc2}{self.downstreamThickness}{config.spc5}{config.spc2}'
+            f'{self.upstreamThickness}{config.spc2}{self.downstreamThickness}{config.spc5}'
             f'Upstream and downstream thickness [cm]\n'
             f'{self.angleOfRotation}{config.spc2}{self.sampleWidth}{config.spc5}'
             f'Angle of rotation and sample width (cm)\n'
@@ -180,8 +187,7 @@ class Normalisation:
             f'Force calculation of corrections?\n'
             f'{str(self.composition)}{compositionSuffix}'
             f'*{config.spc2}0{config.spc2}0{config.spc5}* 0 0 to specify end of composition input\n'
-            f'{Geometry(self.geometry.value).name}{config.spc5}'
-            f'Geometry\n'
+            f'{geometryLine}'
             f'{geometryLines}'
             f'{densityLine}'
             f'{self.tempForNormalisationPC}{config.spc5}'

--- a/src/gudrun_classes/purge_file.py
+++ b/src/gudrun_classes/purge_file.py
@@ -203,7 +203,7 @@ class PurgeFile():
         string : str
             String representation of PurgeFile.
         """
-        HEADER = "'  '  '          '  '/'\n\n"
+        HEADER = f"'  '  '          '  '{os.path.sep}'\n\n"
         TAB = "          "
 
         # Collect data files as strings of the format:

--- a/src/gudrun_classes/sample.py
+++ b/src/gudrun_classes/sample.py
@@ -276,7 +276,7 @@ class Sample:
             f'Force calculation of sample corrections?\n'
             f'{str(self.composition)}{compositionSuffix}'
             f'*{config.spc2}0{config.spc2}0{config.spc5}* 0 0 to specify end of composition input\n'
-            f'{Geometry(self.geometry.value).name}{config.spc5}'
+            f'SameAsBeam{config.spc5}'
             f'Geometry\n'
             f'{geometryLines}'
             f'{densityLine}'

--- a/src/gudrun_classes/sample.py
+++ b/src/gudrun_classes/sample.py
@@ -161,13 +161,11 @@ class Sample:
             String representation of Sample.
         """
 
-        TAB = "          "
-
         nameLine = (
-            f"SAMPLE {self.name}{TAB}"
+            f"SAMPLE {self.name}{config.spc5}"
             if self.name != "SAMPLE"
             else
-            f"SAMPLE{TAB}"
+            f"SAMPLE{config.spc5}"
         )
 
         dataFilesLine = (
@@ -180,9 +178,9 @@ class Sample:
         compositionSuffix = "" if str(self.composition) == "" else "\n"
 
         geometryLines = (
-            f'{self.upstreamThickness}  {self.downstreamThickness}{TAB}'
-            f'Upstream and downstream thickness [cm]\n'
-            f'{self.angleOfRotation}  {self.sampleWidth}{TAB}'
+            f'{self.upstreamThickness}{config.spc2}{self.downstreamThickness}{config.spc5}'
+            f'Upstream and downstream thicknesses [cm]\n'
+            f'{self.angleOfRotation}{config.spc2}{self.sampleWidth}{config.spc5}'
             f'Angle of rotation and sample width (cm)\n'
             if (
                 self.geometry == Geometry.SameAsBeam
@@ -190,9 +188,9 @@ class Sample:
             )
             or self.geometry == Geometry.FLATPLATE
             else
-            f'{self.innerRadius}  {self.outerRadius}{TAB}'
+            f'{self.innerRadius}{config.spc2}{self.outerRadius}{config.spc5}'
             f'Inner and outer radii [cm]\n'
-            f'{self.sampleHeight}{TAB}'
+            f'{self.sampleHeight}{config.spc5}'
             f'Sample height (cm)\n'
         )
 
@@ -202,7 +200,7 @@ class Sample:
             density = self.density
 
         densityLine = (
-            f'{density}{TAB}'
+            f'{density}{config.spc5}'
             f'Density {self.densityUnits.name}?\n'
         )
 
@@ -210,54 +208,54 @@ class Sample:
             CrossSectionSource(self.totalCrossSectionSource.value).name
         )
         crossSectionLine = (
-            f"{crossSectionSource}{TAB}"
+            f"{crossSectionSource}{config.spc5}"
             if self.totalCrossSectionSource != CrossSectionSource.FILE
             else
-            f"{self.crossSectionFilename}{TAB}"
+            f"{self.crossSectionFilename}{config.spc5}"
         )
 
         if self.FTMode == FTModes.NO_FT:
-            topHatWidthLine = f"0{TAB}"
+            topHatWidthLine = f"0{config.spc5}"
         elif self.FTMode == FTModes.SUB_AVERAGE:
-            topHatWidthLine = f"{-self.topHatW}{TAB}"
+            topHatWidthLine = f"{-self.topHatW}{config.spc5}"
         else:
-            topHatWidthLine = f"{self.topHatW}{TAB}"
+            topHatWidthLine = f"{self.topHatW}{config.spc5}"
 
         resonanceLines = (
             bjoin(
                 self.resonanceValues,
-                " Min. and max resonance wavelength [\u212b]. 0  0 to end.\n",
+                '{config.spc5}Min. and max resonance wavelength [\u212b]\n',
                 sameseps=True
             )
         )
         exponentialLines = (
             bjoin(
                 self.exponentialValues,
-                " Exponential amplitude and decay [1/\u212b]\n",
+                f'{config.spc5}Exponential amplitude and decay [1/\u212b]\n',
                 sameseps=True,
                 suffix="0"
             )
         )
 
         selfScatteringLine = (
-            f'{self.fileSelfScattering}{TAB}'
+            f'{self.fileSelfScattering}{config.spc5}'
             f'Name of file containing self scattering'
             f' as a function of wavelength [\u212b]\n'
         )
 
         normaliseLine = (
-            f'{self.normaliseTo.value}{TAB}'
+            f'{self.normaliseTo.value}{config.spc5}'
             f'Normalise to:{self.normaliseTo.name}\n'
         )
 
         unitsLine = (
-            f'{self.outputUnits.value}{TAB}'
+            f'{self.outputUnits.value}{config.spc5}'
             f'Output units: {self.outputUnits.name}\n'
         )
 
         sampleEnvironmentLine = (
-            f'{self.scatteringFraction}  {self.attenuationCoefficient}'
-            f'{TAB}'
+            f'{self.scatteringFraction}{config.spc2}{self.attenuationCoefficient}'
+            f'{config.spc5}'
             f'Sample environment scattering fraction'
             f' and attenuation coefficient [per \u212b]\n'
         )
@@ -271,47 +269,47 @@ class Sample:
 
         return (
             f'\n{nameLine}{{\n\n'
-            f'{len(self.dataFiles)}  {self.periodNumber}{TAB}'
+            f'{len(self.dataFiles)}{config.spc2}{self.periodNumber}{config.spc5}'
             f'Number of  files and period number\n'
             f'{dataFilesLine}'
-            f'{numifyBool(self.forceCalculationOfCorrections)}{TAB}'
+            f'{numifyBool(self.forceCalculationOfCorrections)}{config.spc5}'
             f'Force calculation of sample corrections?\n'
             f'{str(self.composition)}{compositionSuffix}'
-            f'*  0  0{TAB}* 0 0 to specify end of composition input\n'
-            f'{Geometry(self.geometry.value).name}{TAB}'
+            f'*{config.spc2}0{config.spc2}0{config.spc5}* 0 0 to specify end of composition input\n'
+            f'{Geometry(self.geometry.value).name}{config.spc5}'
             f'Geometry\n'
             f'{geometryLines}'
             f'{densityLine}'
-            f'{self.tempForNormalisationPC}{TAB}'
+            f'{self.tempForNormalisationPC}{config.spc5}'
             f'Temperature for sample Placzek correction\n'
             f'{crossSectionLine}'
             f'Total cross section source\n'
-            f'{self.sampleTweakFactor}{TAB}'
+            f'{self.sampleTweakFactor}{config.spc5}'
             f'Sample tweak factor\n'
             f'{topHatWidthLine}'
             f'Top hat width (1/\u212b) for cleaning up Fourier Transform\n'
-            f'{self.minRadFT}{TAB}'
+            f'{self.minRadFT}{config.spc5}'
             f'Minimum radius for FT  [\u212b]\n'
-            f'{self.grBroadening}{TAB}'
+            f'{self.grBroadening}{config.spc5}'
             f'g(r) broadening at r = 1\u212b [\u212b]\n'
             f'{resonanceLines}'
-            f'0  0{TAB}0  0{TAB}'
-            f' to finish specifying wavelength range of resonance\n'
+            f'0{config.spc2}0{config.spc5}0   0{config.spc5}'
+            f'to finish specifying wavelength range of resonance\n'
             f'{exponentialLines}'
-            f'*  0  0{TAB}* 0 0 to specify end of exponential parameter input'
+            f'*{config.spc2}0{config.spc2}0{config.spc5}* 0 0 to specify end of exponential parameter input'
             f'\n'
-            f'{self.normalisationCorrectionFactor}{TAB}'
+            f'{self.normalisationCorrectionFactor}{config.spc5}'
             f'Normalisation correction factor\n'
             f'{selfScatteringLine}'
             f'{normaliseLine}'
-            f'{self.maxRadFT}{TAB}'
+            f'{self.maxRadFT}{config.spc5}'
             f'Maximum radius for FT [\u212b]\n'
             f'{unitsLine}'
-            f'{self.powerForBroadening}{TAB}'
+            f'{self.powerForBroadening}{config.spc5}'
             f'Power for broadening function e.g. 0.5\n'
-            f'{self.stepSize}{TAB}'
+            f'{self.stepSize}{config.spc5}'
             f'Step size [\u212b]\n'
-            f'{numifyBool(self.runThisSample)}{TAB}'
+            f'{numifyBool(self.runThisSample)}{config.spc5}'
             f'Analyse this sample?\n'
             f'{sampleEnvironmentLine}'
             f'\n}}\n\n'

--- a/src/gudrun_classes/sample_background.py
+++ b/src/gudrun_classes/sample_background.py
@@ -72,7 +72,7 @@ class SampleBackground:
         return (
             f'SAMPLE BACKGROUND{TAB}{{\n\n'
             f'{len(self.dataFiles)}  {self.periodNumber}{TAB}'
-            f'Number of files and period number\n'
+            f'Number of  files and period number\n'
             f'{dataFilesLine}\n'
             f'}}\n'
             f'{SAMPLES}'

--- a/src/gui/widgets/slots/container_slots.py
+++ b/src/gui/widgets/slots/container_slots.py
@@ -3,7 +3,7 @@ from src.gudrun_classes import config
 from src.gudrun_classes.enums import (
     CrossSectionSource, FTModes, UnitsOfDensity, Geometry
 )
-
+import os
 
 class ContainerSlots():
 
@@ -621,7 +621,7 @@ class ContainerSlots():
         )
         for file in files:
             if file:
-                target.addItem(file.split("/")[-1])
+                target.addItem(file.split(os.path.sep)[-1])
                 self.handleDataFileInserted(target.item(target.count() - 1))
         if not self.widgetsRefreshing:
             self.parent.setModified()

--- a/src/gui/widgets/slots/instrument_slots.py
+++ b/src/gui/widgets/slots/instrument_slots.py
@@ -1204,7 +1204,7 @@ class InstrumentSlots():
                 ""
             )
         if dir:
-            return filename + "/" if filename else ""
+            return filename + os.path.sep if filename else ""
         else:
             return filename if filename else ""
 

--- a/src/gui/widgets/slots/normalisation_slots.py
+++ b/src/gui/widgets/slots/normalisation_slots.py
@@ -734,7 +734,7 @@ class NormalisationSlots():
         )
         for file in files:
             if file:
-                target.addItem(file.split("/")[-1])
+                target.addItem(file.split(os.path.sep)[-1])
 
     def addDataFiles(self, target, title, regex):
         """

--- a/src/gui/widgets/slots/sample_background_slots.py
+++ b/src/gui/widgets/slots/sample_background_slots.py
@@ -1,5 +1,5 @@
 from PySide6.QtWidgets import QFileDialog
-
+import os
 
 class SampleBackgroundSlots():
 
@@ -82,7 +82,7 @@ class SampleBackgroundSlots():
         )
         for file in files:
             if file:
-                target.addItem(file.split("/")[-1])
+                target.addItem(file.split(os.path.sep)[-1])
                 self.handleDataFileInserted(target.item(target.count() - 1))
         if not self.widgetsRefreshing:
             self.parent.setModified()

--- a/src/gui/widgets/slots/sample_slots.py
+++ b/src/gui/widgets/slots/sample_slots.py
@@ -880,7 +880,7 @@ class SampleSlots():
         )
         for file in files:
             if file:
-                target.addItem(file.split(os.path.sep))[-1])
+                target.addItem(file.split(os.path.sep)[-1])
                 self.handleDataFileInserted(target.item(target.count() - 1))
         if not self.widgetsRefreshing:
             self.parent.setModified()

--- a/src/gui/widgets/slots/sample_slots.py
+++ b/src/gui/widgets/slots/sample_slots.py
@@ -4,7 +4,7 @@ from src.gudrun_classes.enums import (
 )
 from src.gudrun_classes import config
 from PySide6.QtWidgets import QAbstractItemView, QFileDialog
-
+import os
 
 class SampleSlots():
 
@@ -880,7 +880,7 @@ class SampleSlots():
         )
         for file in files:
             if file:
-                target.addItem(file.split("/")[-1])
+                target.addItem(file.split(os.path.sep))[-1])
                 self.handleDataFileInserted(target.item(target.count() - 1))
         if not self.widgetsRefreshing:
             self.parent.setModified()

--- a/src/scripts/utils.py
+++ b/src/scripts/utils.py
@@ -126,7 +126,7 @@ def bjoin(iterable, sep, lastsep=None, endsep='', sameseps=False, suffix=None):
         for i in iterable
     ]
     iterable = [
-        spacify(i)
+        spacify(i, num_spaces=2)
         if isinstance(i, (list, tuple))
         else i
         for i in iterable


### PR DESCRIPTION
PR to create a sense of backwards compatibility between GudPy and the Gudrun Java GUI. Files in the GudPy input format can be loaded into the Gudrun GUI.

Saving of components has been modified slightly, where curly braces were previously used, parenthesis are now used - since curly braces break the Gudrun GUI - as these are used as section delimiters there.

Closes #284.