### PR TITLE
Chart updates #1

### DIFF
--- a/src/gui/widgets/charts/chart.py
+++ b/src/gui/widgets/charts/chart.py
@@ -28,6 +28,8 @@ class GudPyChart(QChart):
         self.logarithmicYAxis = QLogValueAxis(self)
         self.logarithmicYAxis.setBase(10.0)
 
+        self.plotMode = PlotModes.SF_MINT01
+
     def connectMarkers(self):
         for marker in self.legend().markers():
             marker.clicked.connect(self.handleMarkerClicked)

--- a/src/gui/widgets/charts/chart.py
+++ b/src/gui/widgets/charts/chart.py
@@ -87,15 +87,15 @@ class GudPyChart(QChart):
             self.removeAxis(axis)
 
         plotsDCS = self.plotMode in [
-            PlotModes.SF, PlotModes.SF_MDCS01,
-            PlotModes.SF_CANS, PlotModes.SF_MDCS01_CANS
+            PlotModes.SF_MDCS01,
+            PlotModes.SF_MDCS01_CANS
         ]
         plotsSamples = self.plotMode in [
-            PlotModes.SF, PlotModes.SF_MDCS01,
+            PlotModes.SF_MDCS01,
             PlotModes.SF_MINT01, PlotModes.RDF
         ]
         plotsContainers = self.plotMode in [
-            PlotModes.SF_CANS, PlotModes.SF_MINT01_CANS,
+            PlotModes.SF_MINT01_CANS,
             PlotModes.SF_MDCS01_CANS, PlotModes.RDF_CANS
         ]
         for sample in self.samples:
@@ -125,8 +125,8 @@ class GudPyChart(QChart):
 
         # Label axes
         if self.plotMode in [
-            PlotModes.SF, PlotModes.SF_MINT01,
-            PlotModes.SF_MDCS01, PlotModes.SF_CANS,
+           PlotModes.SF_MINT01,
+            PlotModes.SF_MDCS01,
             PlotModes.SF_MINT01_CANS, PlotModes.SF_MDCS01_CANS
         ]:
             XLabel = "Q, 1\u212b"
@@ -209,13 +209,7 @@ class GudPyChart(QChart):
 
     def isSampleVisible(self, sample):
 
-        if self.plotMode in [PlotModes.SF, PlotModes.SF_CANS]:
-            return (
-                self.configs[sample].mint01Series.isVisible()
-                | self.configs[sample].mdcs01Series.isVisible()
-                | self.configs[sample].dcsSeries.isVisible()
-            )
-        elif self.plotMode in [PlotModes.SF_MINT01, PlotModes.SF_MINT01_CANS]:
+        if self.plotMode in [PlotModes.SF_MINT01, PlotModes.SF_MINT01_CANS]:
             return self.configs[sample].mint01Series.isVisible()
         elif self.plotMode in [PlotModes.SF_MDCS01, PlotModes.SF_MDCS01_CANS]:
             return (

--- a/src/gui/widgets/charts/chart.py
+++ b/src/gui/widgets/charts/chart.py
@@ -1,6 +1,7 @@
 from PySide6.QtCharts import QChart, QLegend, QLegendMarker, QLogValueAxis
 from PySide6.QtCore import QObject, Qt
 from PySide6.QtGui import QPen
+from PySide6.QtWidgets import QGraphicsTextItem
 from src.gudrun_classes.sample import Sample
 from src.gudrun_classes.container import Container
 from src.gui.widgets.charts.sample_plot_config import SamplePlotConfig
@@ -29,6 +30,8 @@ class GudPyChart(QChart):
         self.logarithmicYAxis.setBase(10.0)
 
         self.plotMode = PlotModes.SF_MINT01
+
+        self.label = QGraphicsTextItem("x=,y=", self)
 
     def connectMarkers(self):
         for marker in self.legend().markers():

--- a/src/gui/widgets/charts/chart.py
+++ b/src/gui/widgets/charts/chart.py
@@ -89,14 +89,18 @@ class GudPyChart(QChart):
             self.removeAxis(axis)
 
         plotsDCS = self.plotMode in [
+            PlotModes.SF,
+            PlotModes.SF_CANS,
             PlotModes.SF_MDCS01,
             PlotModes.SF_MDCS01_CANS
         ]
         plotsSamples = self.plotMode in [
+            PlotModes.SF,
             PlotModes.SF_MDCS01,
             PlotModes.SF_MINT01, PlotModes.RDF
         ]
         plotsContainers = self.plotMode in [
+            PlotModes.SF_CANS,
             PlotModes.SF_MINT01_CANS,
             PlotModes.SF_MDCS01_CANS, PlotModes.RDF_CANS
         ]
@@ -127,8 +131,10 @@ class GudPyChart(QChart):
 
         # Label axes
         if self.plotMode in [
-           PlotModes.SF_MINT01,
+            PlotModes.SF,
+            PlotModes.SF_MINT01,
             PlotModes.SF_MDCS01,
+            PlotModes.SF_CANS,
             PlotModes.SF_MINT01_CANS, PlotModes.SF_MDCS01_CANS
         ]:
             XLabel = "Q, 1\u212b"

--- a/src/gui/widgets/charts/chartview.py
+++ b/src/gui/widgets/charts/chartview.py
@@ -1,9 +1,9 @@
-from PySide6.QtCharts import QChartView
-from PySide6.QtCore import QRectF, QRect, Qt
+from PySide6.QtCharts import QChartView, QChart
+from PySide6.QtCore import QRectF, QRect, Qt, QPoint
 from PySide6.QtGui import (
     QAction, QClipboard, QCursor, QPainter, QMouseEvent
 )
-from PySide6.QtWidgets import QApplication, QMenu, QSizePolicy
+from PySide6.QtWidgets import QApplication, QMenu, QSizePolicy, QGraphicsTextItem
 from src.gudrun_classes.container import Container
 from src.gudrun_classes.sample import Sample
 from src.gui.widgets.charts.enums import PlotModes, SeriesTypes
@@ -60,6 +60,8 @@ class GudPyChartView(QChartView):
 
         self.previousPos = 0
 
+        self.setChart(QChart())
+
     def wheelEvent(self, event):
         """
         Event handler called when the scroll wheel is used.
@@ -105,6 +107,10 @@ class GudPyChartView(QChartView):
 
                 self.previousPos = event.pos()
                 event.accept()
+            else:
+                if self.chart().plotArea().contains(event.pos()):
+                    pos = self.chart().mapToValue(event.pos())
+                    self.label.setPlainText(f"{round(pos.y(), 2)}, {round(pos.x(), 2)}")
             return super().mouseMoveEvent(event)
 
     def mousePressEvent(self, event):
@@ -337,3 +343,13 @@ class GudPyChartView(QChartView):
         Toggles logarithmic axes in the chart.
         """
         self.chart().toggleLogarithmicAxis(axis)
+
+    def setChart(self, chart):
+        self.label = QGraphicsTextItem("x,y", chart)
+        self.label.setPos(self.mapToScene(25,self.sceneRect().height()-50))
+        self.label.show()
+        return super().setChart(chart)
+    
+    def resizeEvent(self, event):
+        self.label.setPos(self.mapToScene(25,self.sceneRect().height()-50))
+        return super().resizeEvent(event)

--- a/src/gui/widgets/charts/chartview.py
+++ b/src/gui/widgets/charts/chartview.py
@@ -111,7 +111,7 @@ class GudPyChartView(QChartView):
                 if self.chart().plotArea().contains(event.pos()):
                     pos = self.chart().mapToValue(event.pos())
                     self.chart().label.setPlainText(
-                        f"x={round(pos.x(), 2)},y={round(pos.y(), 2)}"
+                        f"x={round(pos.x(), 4)}, y={round(pos.y(), 4)}"
                     )
                     if not self.chart().label.isVisible():
                         self.chart().label.show()

--- a/src/gui/widgets/charts/chartview.py
+++ b/src/gui/widgets/charts/chartview.py
@@ -1,9 +1,11 @@
 from PySide6.QtCharts import QChartView, QChart
-from PySide6.QtCore import QRectF, QRect, Qt, QPoint
+from PySide6.QtCore import QRectF, QRect, Qt
 from PySide6.QtGui import (
     QAction, QClipboard, QCursor, QPainter, QMouseEvent
 )
-from PySide6.QtWidgets import QApplication, QMenu, QSizePolicy, QGraphicsTextItem
+from PySide6.QtWidgets import (
+    QApplication, QMenu, QSizePolicy, QGraphicsTextItem
+)
 from src.gudrun_classes.container import Container
 from src.gudrun_classes.sample import Sample
 from src.gui.widgets.charts.enums import PlotModes, SeriesTypes
@@ -110,7 +112,9 @@ class GudPyChartView(QChartView):
             else:
                 if self.chart().plotArea().contains(event.pos()):
                     pos = self.chart().mapToValue(event.pos())
-                    self.label.setPlainText(f"{round(pos.y(), 2)}, {round(pos.x(), 2)}")
+                    self.label.setPlainText(
+                        f"{round(pos.y(), 2)}, {round(pos.x(), 2)}"
+                    )
             return super().mouseMoveEvent(event)
 
     def mousePressEvent(self, event):
@@ -346,10 +350,10 @@ class GudPyChartView(QChartView):
 
     def setChart(self, chart):
         self.label = QGraphicsTextItem("x,y", chart)
-        self.label.setPos(self.mapToScene(25,self.sceneRect().height()-50))
+        self.label.setPos(self.mapToScene(25, self.sceneRect().height()-50))
         self.label.show()
         return super().setChart(chart)
-    
+
     def resizeEvent(self, event):
-        self.label.setPos(self.mapToScene(25,self.sceneRect().height()-50))
+        self.label.setPos(self.mapToScene(25, self.sceneRect().height()-50))
         return super().resizeEvent(event)

--- a/src/gui/widgets/charts/chartview.py
+++ b/src/gui/widgets/charts/chartview.py
@@ -1,10 +1,10 @@
-from PySide6.QtCharts import QChartView, QChart
+from PySide6.QtCharts import QChartView
 from PySide6.QtCore import QRectF, QRect, Qt
 from PySide6.QtGui import (
     QAction, QClipboard, QCursor, QPainter, QMouseEvent
 )
 from PySide6.QtWidgets import (
-    QApplication, QMenu, QSizePolicy, QGraphicsTextItem
+    QApplication, QMenu, QSizePolicy
 )
 from src.gudrun_classes.container import Container
 from src.gudrun_classes.sample import Sample
@@ -356,5 +356,7 @@ class GudPyChartView(QChartView):
         return super().setChart(chart)
 
     def resizeEvent(self, event):
-        self.chart().label.setPos(self.mapToScene(25, self.sceneRect().height()-50))
+        self.chart().label.setPos(
+            self.mapToScene(25, self.sceneRect().height()-50)
+        )
         return super().resizeEvent(event)

--- a/src/gui/widgets/charts/chartview.py
+++ b/src/gui/widgets/charts/chartview.py
@@ -62,8 +62,6 @@ class GudPyChartView(QChartView):
 
         self.previousPos = 0
 
-        self.setChart(QChart())
-
     def wheelEvent(self, event):
         """
         Event handler called when the scroll wheel is used.
@@ -112,9 +110,13 @@ class GudPyChartView(QChartView):
             else:
                 if self.chart().plotArea().contains(event.pos()):
                     pos = self.chart().mapToValue(event.pos())
-                    self.label.setPlainText(
-                        f"{round(pos.y(), 2)}, {round(pos.x(), 2)}"
+                    self.chart().label.setPlainText(
+                        f"x={round(pos.x(), 2)},y={round(pos.y(), 2)}"
                     )
+                    if not self.chart().label.isVisible():
+                        self.chart().label.show()
+                else:
+                    self.chart().label.hide()
             return super().mouseMoveEvent(event)
 
     def mousePressEvent(self, event):
@@ -349,11 +351,10 @@ class GudPyChartView(QChartView):
         self.chart().toggleLogarithmicAxis(axis)
 
     def setChart(self, chart):
-        self.label = QGraphicsTextItem("x,y", chart)
-        self.label.setPos(self.mapToScene(25, self.sceneRect().height()-50))
-        self.label.show()
+        chart.label.setPos(self.mapToScene(25, self.sceneRect().height()-50))
+        chart.label.show()
         return super().setChart(chart)
 
     def resizeEvent(self, event):
-        self.label.setPos(self.mapToScene(25, self.sceneRect().height()-50))
+        self.chart().label.setPos(self.mapToScene(25, self.sceneRect().height()-50))
         return super().resizeEvent(event)

--- a/src/gui/widgets/charts/chartview.py
+++ b/src/gui/widgets/charts/chartview.py
@@ -1,7 +1,7 @@
 from PySide6.QtCharts import QChartView
 from PySide6.QtCore import QRectF, QRect, Qt
 from PySide6.QtGui import (
-    QAction, QClipboard, QCursor, QPainter
+    QAction, QClipboard, QCursor, QPainter, QMouseEvent
 )
 from PySide6.QtWidgets import QApplication, QMenu, QSizePolicy
 from src.gudrun_classes.container import Container
@@ -93,18 +93,19 @@ class GudPyChartView(QChartView):
         self.chart().scroll(delta.x(), -delta.y())
 
     def mouseMoveEvent(self, event):
-        if event.buttons() & Qt.MouseButton.MiddleButton:
+        if isinstance(event, QMouseEvent):
+            if event.buttons() & Qt.MouseButton.MiddleButton:
 
-            if self.previousPos:
-                offset = event.pos() - self.previousPos
-            else:
-                offset = event.pos()
-            self.chart().zoom(1 + 0.00000001)
-            self.chart().scroll(-offset.x(), offset.y())
+                if self.previousPos:
+                    offset = event.pos() - self.previousPos
+                else:
+                    offset = event.pos()
+                self.chart().zoom(1 + 0.00000001)
+                self.chart().scroll(-offset.x(), offset.y())
 
-            self.previousPos = event.pos()
-            event.accept()
-        return super().mouseMoveEvent(event)
+                self.previousPos = event.pos()
+                event.accept()
+            return super().mouseMoveEvent(event)
 
     def mousePressEvent(self, event):
         if event.button() == Qt.MouseButton.MiddleButton:
@@ -248,34 +249,6 @@ class GudPyChartView(QChartView):
             self.menu.addMenu(toggleLogarithmicMenu)
 
             if self.chart().plotMode in [
-                PlotModes.SF,
-                PlotModes.SF_CANS
-            ]:
-                showMint01Action = QAction("Show mint01 data", self.menu)
-                showMint01Action.setCheckable(True)
-                showMint01Action.setChecked(
-                    self.chart().isVisible(SeriesTypes.MINT01)
-                )
-                showMint01Action.triggered.connect(
-                    lambda: self.chart().toggleVisible(
-                        SeriesTypes.MINT01
-                    )
-                )
-                self.menu.addAction(showMint01Action)
-
-                showMdcs01Action = QAction("Show mdcs01 data", self.menu)
-                showMdcs01Action.setCheckable(True)
-                showMdcs01Action.setChecked(
-                    self.chart().isVisible(SeriesTypes.MDCS01)
-                )
-                showMdcs01Action.triggered.connect(
-                    lambda: self.chart().toggleVisible(
-                        SeriesTypes.MDCS01
-                    )
-                )
-                self.menu.addAction(showMdcs01Action)
-            if self.chart().plotMode in [
-                PlotModes.SF, PlotModes.SF_CANS,
                 PlotModes.SF_MDCS01, PlotModes.SF_MDCS01_CANS
             ]:
                 showDCSLevelAction = QAction("Show dcs level", self.menu)
@@ -324,7 +297,7 @@ class GudPyChartView(QChartView):
                 showMenu.setTitle("Show..")
                 actionMap = {}
                 if self.chart().plotMode in [
-                    PlotModes.SF, PlotModes.SF_MINT01,
+                    PlotModes.SF_MINT01,
                     PlotModes.SF_MDCS01, PlotModes.RDF
                 ]:
                     samples = [
@@ -332,7 +305,7 @@ class GudPyChartView(QChartView):
                         if isinstance(sample, Sample)
                     ]
                 elif self.chart().plotMode in [
-                    PlotModes.SF_CANS, PlotModes.SF_MINT01_CANS,
+                    PlotModes.SF_MINT01_CANS,
                     PlotModes.SF_MDCS01_CANS, PlotModes.RDF_CANS
                 ]:
                     samples = [

--- a/src/gui/widgets/charts/enums.py
+++ b/src/gui/widgets/charts/enums.py
@@ -13,14 +13,12 @@ def enumFromDict(clsname, _dict):
 
 
 PLOT_MODES = {
-    0: ["Structure Factor (mint01, mdcs01)", "SF"],
-    1: ["Structure Factor (mint01)", "SF_MINT01"],
-    2: ["Structure Factor (mdcs01)", "SF_MDCS01"],
-    3: ["Radial Distribution Functions", "RDF"],
-    4: ["Structure Factor (mint01, mdcs01), (Cans)", "SF_CANS"],
-    5: ["Radial Distribution Functions (Cans)", "RDF_CANS"],
-    6: ["Structure Factor (mint01), (Cans)", "SF_MINT01_CANS"],
-    7: ["Structure Factor (mdcs01), (Cans)", "SF_MDCS01_CANS"],
+    0: ["Structure Factor (mint01)", "SF_MINT01"],
+    1: ["Structure Factor (mdcs01)", "SF_MDCS01"],
+    2: ["Radial Distribution Functions", "RDF"],
+    3: ["Radial Distribution Functions (Cans)", "RDF_CANS"],
+    4: ["Structure Factor (mint01), (Cans)", "SF_MINT01_CANS"],
+    5: ["Structure Factor (mdcs01), (Cans)", "SF_MDCS01_CANS"],
 }
 
 

--- a/src/gui/widgets/charts/enums.py
+++ b/src/gui/widgets/charts/enums.py
@@ -13,16 +13,20 @@ def enumFromDict(clsname, _dict):
 
 
 PLOT_MODES = {
-    0: ["Structure Factor (mint01)", "SF_MINT01"],
-    1: ["Structure Factor (mdcs01)", "SF_MDCS01"],
-    2: ["Radial Distribution Functions", "RDF"],
-    3: ["Structure Factor (mint01), Radial Distribution Functions", "SF_MINT01_RDF"],
-    4: ["Structure Factor (mdcs01), Radial Distribution Functions", "SF_MDCS01_RDF"],
-    5: ["Structure Factor (mint01), (Cans)", "SF_MINT01_CANS"],
-    6: ["Structure Factor (mdcs01), (Cans)", "SF_MDCS01_CANS"],
-    7: ["Radial Distribution Functions (Cans)", "RDF_CANS"],
-    8: ["Structure Factor (mint01), Radial Distribution Functions (Cans)", "SF_MINT01_RDF_CANS"],
-    9: ["Structure Factor (mdcs01), Radial Distribution Functions (Cans)", "SF_MDCS01_RDF_CANS"]
+    0: ["Structure Factor (mint01, mdcs01)", "SF"],
+    1: ["Structure Factor (mint01)", "SF_MINT01"],
+    2: ["Structure Factor (mdcs01)", "SF_MDCS01"],
+    3: ["Radial Distribution Functions", "RDF"],
+    4: ["Structure Factor (mint01, mdcs01), Radial Distribution Functions", "SF_RDF"],
+    5: ["Structure Factor (mint01), Radial Distribution Functions", "SF_MINT01_RDF"],
+    6: ["Structure Factor (mdcs01), Radial Distribution Functions", "SF_MDCS01_RDF"],
+    7: ["Structure Factor (mint01, mdcs01) (Cans)", "SF_CANS"],
+    8: ["Structure Factor (mint01), (Cans)", "SF_MINT01_CANS"],
+    9: ["Structure Factor (mdcs01), (Cans)", "SF_MDCS01_CANS"],
+    10: ["Radial Distribution Functions (Cans)", "RDF_CANS"],
+    11: ["Structure Factor (mint01, mdcs01), Radial Distribution Functions (Cans)", "SF_RDF_CANS"],
+    12: ["Structure Factor (mint01), Radial Distribution Functions (Cans)", "SF_MINT01_RDF_CANS"],
+    13: ["Structure Factor (mdcs01), Radial Distribution Functions (Cans)", "SF_MDCS01_RDF_CANS"]
 }
 
 
@@ -34,7 +38,9 @@ SPLIT_PLOTS = {
     PlotModes.SF_MINT01_RDF: (PlotModes.SF_MINT01, PlotModes.RDF),
     PlotModes.SF_MDCS01_RDF: (PlotModes.SF_MDCS01, PlotModes.RDF),
     PlotModes.SF_MINT01_RDF_CANS: (PlotModes.SF_MINT01_CANS, PlotModes.RDF_CANS),
-    PlotModes.SF_MDCS01_RDF_CANS: (PlotModes.SF_MDCS01_CANS, PlotModes.RDF_CANS)
+    PlotModes.SF_MDCS01_RDF_CANS: (PlotModes.SF_MDCS01_CANS, PlotModes.RDF_CANS),
+    PlotModes.SF_RDF: (PlotModes.SF, PlotModes.RDF),
+    PlotModes.SF_RDF_CANS: (PlotModes.SF_CANS, PlotModes.RDF_CANS)
 }
 
 

--- a/src/gui/widgets/charts/enums.py
+++ b/src/gui/widgets/charts/enums.py
@@ -43,7 +43,7 @@ PLOT_MODES = {
         "SF_MINT01_RDF_CANS"
     ],
     13: [
-        "Structure Factor (mdcs01), Radial Distribution Functions (Cans)"
+        "Structure Factor (mdcs01), Radial Distribution Functions (Cans)",
         "SF_MDCS01_RDF_CANS"
     ]
 }

--- a/src/gui/widgets/charts/enums.py
+++ b/src/gui/widgets/charts/enums.py
@@ -16,15 +16,26 @@ PLOT_MODES = {
     0: ["Structure Factor (mint01)", "SF_MINT01"],
     1: ["Structure Factor (mdcs01)", "SF_MDCS01"],
     2: ["Radial Distribution Functions", "RDF"],
-    3: ["Radial Distribution Functions (Cans)", "RDF_CANS"],
-    4: ["Structure Factor (mint01), (Cans)", "SF_MINT01_CANS"],
-    5: ["Structure Factor (mdcs01), (Cans)", "SF_MDCS01_CANS"],
+    3: ["Structure Factor (mint01), Radial Distribution Functions", "SF_MINT01_RDF"],
+    4: ["Structure Factor (mdcs01), Radial Distribution Functions", "SF_MDCS01_RDF"],
+    5: ["Structure Factor (mint01), (Cans)", "SF_MINT01_CANS"],
+    6: ["Structure Factor (mdcs01), (Cans)", "SF_MDCS01_CANS"],
+    7: ["Radial Distribution Functions (Cans)", "RDF_CANS"],
+    8: ["Structure Factor (mint01), Radial Distribution Functions (Cans)", "SF_MINT01_RDF_CANS"],
+    9: ["Structure Factor (mdcs01), Radial Distribution Functions (Cans)", "SF_MDCS01_RDF_CANS"]
 }
 
 
 PlotModes = enumFromDict(
     "PlotModes", PLOT_MODES
 )
+
+SPLIT_PLOTS = {
+    PlotModes.SF_MINT01_RDF: (PlotModes.SF_MINT01, PlotModes.RDF),
+    PlotModes.SF_MDCS01_RDF: (PlotModes.SF_MDCS01, PlotModes.RDF),
+    PlotModes.SF_MINT01_RDF_CANS: (PlotModes.SF_MINT01_CANS, PlotModes.RDF_CANS),
+    PlotModes.SF_MDCS01_RDF_CANS: (PlotModes.SF_MDCS01_CANS, PlotModes.RDF_CANS)
+}
 
 
 class SeriesTypes(Enum):

--- a/src/gui/widgets/charts/enums.py
+++ b/src/gui/widgets/charts/enums.py
@@ -17,16 +17,35 @@ PLOT_MODES = {
     1: ["Structure Factor (mint01)", "SF_MINT01"],
     2: ["Structure Factor (mdcs01)", "SF_MDCS01"],
     3: ["Radial Distribution Functions", "RDF"],
-    4: ["Structure Factor (mint01, mdcs01), Radial Distribution Functions", "SF_RDF"],
-    5: ["Structure Factor (mint01), Radial Distribution Functions", "SF_MINT01_RDF"],
-    6: ["Structure Factor (mdcs01), Radial Distribution Functions", "SF_MDCS01_RDF"],
+    4: [
+        "Structure Factor (mint01, mdcs01), Radial Distribution Functions",
+        "SF_RDF"
+    ],
+    5: [
+        "Structure Factor (mint01), Radial Distribution Functions",
+        "SF_MINT01_RDF"
+    ],
+    6: [
+        "Structure Factor (mdcs01), Radial Distribution Functions",
+        "SF_MDCS01_RDF"
+    ],
     7: ["Structure Factor (mint01, mdcs01) (Cans)", "SF_CANS"],
     8: ["Structure Factor (mint01), (Cans)", "SF_MINT01_CANS"],
     9: ["Structure Factor (mdcs01), (Cans)", "SF_MDCS01_CANS"],
     10: ["Radial Distribution Functions (Cans)", "RDF_CANS"],
-    11: ["Structure Factor (mint01, mdcs01), Radial Distribution Functions (Cans)", "SF_RDF_CANS"],
-    12: ["Structure Factor (mint01), Radial Distribution Functions (Cans)", "SF_MINT01_RDF_CANS"],
-    13: ["Structure Factor (mdcs01), Radial Distribution Functions (Cans)", "SF_MDCS01_RDF_CANS"]
+    11: [
+        "Structure Factor (mint01, mdcs01),"
+        "Radial Distribution Functions (Cans)",
+        "SF_RDF_CANS"
+    ],
+    12: [
+        "Structure Factor (mint01), Radial Distribution Functions (Cans)",
+        "SF_MINT01_RDF_CANS"
+    ],
+    13: [
+        "Structure Factor (mdcs01), Radial Distribution Functions (Cans)"
+        "SF_MDCS01_RDF_CANS"
+    ]
 }
 
 
@@ -37,8 +56,12 @@ PlotModes = enumFromDict(
 SPLIT_PLOTS = {
     PlotModes.SF_MINT01_RDF: (PlotModes.SF_MINT01, PlotModes.RDF),
     PlotModes.SF_MDCS01_RDF: (PlotModes.SF_MDCS01, PlotModes.RDF),
-    PlotModes.SF_MINT01_RDF_CANS: (PlotModes.SF_MINT01_CANS, PlotModes.RDF_CANS),
-    PlotModes.SF_MDCS01_RDF_CANS: (PlotModes.SF_MDCS01_CANS, PlotModes.RDF_CANS),
+    PlotModes.SF_MINT01_RDF_CANS: (
+        PlotModes.SF_MINT01_CANS, PlotModes.RDF_CANS
+    ),
+    PlotModes.SF_MDCS01_RDF_CANS: (
+        PlotModes.SF_MDCS01_CANS, PlotModes.RDF_CANS
+    ),
     PlotModes.SF_RDF: (PlotModes.SF, PlotModes.RDF),
     PlotModes.SF_RDF_CANS: (PlotModes.SF_CANS, PlotModes.RDF_CANS)
 }

--- a/src/gui/widgets/charts/sample_plot_config.py
+++ b/src/gui/widgets/charts/sample_plot_config.py
@@ -112,12 +112,6 @@ class SamplePlotConfig():
             self.mgor01Series
         ]
 
-    def SF(self):
-        return [
-            self.mint01Series,
-            self.mdcs01Series,
-            self.dcsSeries
-        ]
 
     def SF_MINT01(self):
         return [
@@ -139,11 +133,9 @@ class SamplePlotConfig():
     def plotData(self, plotMode):
         if len(self.sample.dataFiles.dataFiles):
             return {
-                PlotModes.SF: self.SF,
                 PlotModes.SF_MINT01: self.SF_MINT01,
                 PlotModes.SF_MDCS01: self.SF_MDCS01,
                 PlotModes.RDF: self.RDF,
-                PlotModes.SF_CANS: self.SF,
                 PlotModes.SF_MINT01_CANS: self.SF_MINT01,
                 PlotModes.SF_MDCS01_CANS: self.SF_MDCS01,
                 PlotModes.RDF_CANS: self.RDF

--- a/src/gui/widgets/charts/sample_plot_config.py
+++ b/src/gui/widgets/charts/sample_plot_config.py
@@ -112,6 +112,12 @@ class SamplePlotConfig():
             self.mgor01Series
         ]
 
+    def SF(self):
+        return [
+            self.mint01Series,
+            self.mdcs01Series,
+            self.dcsSeries
+        ]
 
     def SF_MINT01(self):
         return [
@@ -133,9 +139,11 @@ class SamplePlotConfig():
     def plotData(self, plotMode):
         if len(self.sample.dataFiles.dataFiles):
             return {
+                PlotModes.SF: self.SF,
                 PlotModes.SF_MINT01: self.SF_MINT01,
                 PlotModes.SF_MDCS01: self.SF_MDCS01,
                 PlotModes.RDF: self.RDF,
+                PlotModes.SF_CANS: self.SF,
                 PlotModes.SF_MINT01_CANS: self.SF_MINT01,
                 PlotModes.SF_MDCS01_CANS: self.SF_MDCS01,
                 PlotModes.RDF_CANS: self.RDF

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -263,11 +263,6 @@ class GudPyMainWindow(QMainWindow):
         )
 
         self.mainWidget.topAllPlotComboBox.addItem(
-            PlotModes.SF.name,
-            PlotModes.SF
-        )
-
-        self.mainWidget.topAllPlotComboBox.addItem(
             PlotModes.SF_MINT01.name,
             PlotModes.SF_MINT01
         )
@@ -275,11 +270,6 @@ class GudPyMainWindow(QMainWindow):
         self.mainWidget.topAllPlotComboBox.addItem(
             PlotModes.SF_MDCS01.name,
             PlotModes.SF_MDCS01
-        )
-
-        self.mainWidget.topAllPlotComboBox.addItem(
-            PlotModes.SF_CANS.name,
-            PlotModes.SF_CANS
         )
 
         self.mainWidget.topAllPlotComboBox.addItem(
@@ -311,11 +301,6 @@ class GudPyMainWindow(QMainWindow):
         )
 
         self.mainWidget.topPlotComboBox.addItem(
-            PlotModes.SF.name,
-            PlotModes.SF
-        )
-
-        self.mainWidget.topPlotComboBox.addItem(
             PlotModes.SF_MINT01.name,
             PlotModes.SF_MINT01
         )
@@ -339,18 +324,13 @@ class GudPyMainWindow(QMainWindow):
         )
 
         self.mainWidget.topContainerPlotComboBox.addItem(
-            PlotModes.SF.name,
-            PlotModes.SF
+            PlotModes.SF_MINT01_CANS.name,
+            PlotModes.SF_MINT01_CANS
         )
 
         self.mainWidget.topContainerPlotComboBox.addItem(
-            PlotModes.SF_MINT01.name,
-            PlotModes.SF_MINT01
-        )
-
-        self.mainWidget.topContainerPlotComboBox.addItem(
-            PlotModes.SF_MDCS01.name,
-            PlotModes.SF_MDCS01
+            PlotModes.SF_MDCS01_CANS.name,
+            PlotModes.SF_MDCS01_CANS
         )
 
         self.mainWidget.topContainerPlotComboBox.currentIndexChanged.connect(
@@ -358,11 +338,11 @@ class GudPyMainWindow(QMainWindow):
         )
 
         self.mainWidget.bottomContainerPlotComboBox.addItem(
-            PlotModes.RDF.name,
-            PlotModes.RDF
+            PlotModes.RDF_CANS.name,
+            PlotModes.RDF_CANS
         )
 
-        self.mainWidget.bottomPlotComboBox.currentIndexChanged.connect(
+        self.mainWidget.bottomContainerPlotComboBox.currentIndexChanged.connect(
             self.handleContainerBottomPlotModeChanged
         )
 
@@ -655,9 +635,8 @@ class GudPyMainWindow(QMainWindow):
             )
 
             plotsMap = {
-                PlotModes.SF: 0,
-                PlotModes.SF_MINT01: 1,
-                PlotModes.SF_MDCS01: 2,
+                PlotModes.SF_MINT01: 0,
+                PlotModes.SF_MDCS01: 1,
                 PlotModes.RDF: 0
             }
 
@@ -712,10 +691,10 @@ class GudPyMainWindow(QMainWindow):
                 topPlot, bottomPlot, gudFile = (
                     self.results[self.mainWidget.objectTree.currentObject()]
                 )
-            if not topPlot.series() or not bottomPlot.series():
-                self.mainWidget.containerSplitter.setSizes([1, 0])
-            else:
+            if topPlot.series() or bottomPlot.series():
                 self.mainWidget.containerSplitter.setSizes([2, 1])
+            else:
+                self.mainWidget.containerSplitter.setSizes([1, 0])
 
             self.mainWidget.containerTopPlot.setChart(
                 topPlot
@@ -725,16 +704,15 @@ class GudPyMainWindow(QMainWindow):
             )
 
             plotsMap = {
-                PlotModes.SF: 0,
-                PlotModes.SF_MINT01: 1,
-                PlotModes.SF_MDCS01: 2,
-                PlotModes.RDF: 0
+                PlotModes.SF_MINT01_CANS: 0,
+                PlotModes.SF_MDCS01_CANS: 1,
+                PlotModes.RDF_CANS: 0
             }
 
-            self.mainWidget.topPlotComboBox.setCurrentIndex(
+            self.mainWidget.topContainerPlotComboBox.setCurrentIndex(
                 plotsMap[topPlot.plotMode]
             )
-            self.mainWidget.bottomPlotComboBox.setCurrentIndex(
+            self.mainWidget.bottomContainerPlotComboBox.setCurrentIndex(
                 plotsMap[bottomPlot.plotMode]
             )
             if gudFile:
@@ -767,12 +745,18 @@ class GudPyMainWindow(QMainWindow):
                 self.gudrunFile
             )
             topChart.addSample(sample)
-            topChart.plot(self.mainWidget.topPlotComboBox.itemData(self.mainWidget.topPlotComboBox.currentIndex()))
+            if isinstance(sample, Sample):
+                topPlotMode = self.mainWidget.topPlotComboBox.itemData(self.mainWidget.topPlotComboBox.currentIndex())
+                bottomPlotMode = self.mainWidget.bottomPlotComboBox.itemData(self.mainWidget.bottomPlotComboBox.currentIndex())
+            else:
+                topPlotMode = self.mainWidget.topContainerPlotComboBox.itemData(self.mainWidget.topContainerPlotComboBox.currentIndex())
+                bottomPlotMode = self.mainWidget.bottomContainerPlotComboBox.itemData(self.mainWidget.bottomContainerPlotComboBox.currentIndex())
+            topChart.plot(topPlotMode)
             bottomChart = GudPyChart(
                 self.gudrunFile
             )
             bottomChart.addSample(sample)
-            bottomChart.plot(self.mainWidget.bottomPlotComboBox.itemData(self.mainWidget.bottomPlotComboBox.currentIndex()))
+            bottomChart.plot(bottomPlotMode)
             path = None
             if len(sample.dataFiles.dataFiles):
                 path = breplace(

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -48,7 +48,7 @@ from src.gui.widgets.exponential_spinbox import ExponentialSpinBox
 from src.gui.widgets.charts.chart import GudPyChart
 from src.gui.widgets.charts.chartview import GudPyChartView
 from src.gui.widgets.charts.beam_plot import BeamChart
-from src.gui.widgets.charts.enums import PLOT_MODES, PlotModes, SPLIT_PLOTS
+from src.gui.widgets.charts.enums import PlotModes, SPLIT_PLOTS
 
 from src.gudrun_classes.enums import Geometry
 from src.gui.widgets.slots.instrument_slots import InstrumentSlots
@@ -269,22 +269,35 @@ class GudPyMainWindow(QMainWindow):
 
         self.mainWidget.bottomPlotFrame.setVisible(False)
 
-        for plotMode in [plotMode for plotMode in PlotModes if plotMode not in [PlotModes.SF, PlotModes.SF_RDF, PlotModes.SF_CANS, PlotModes.SF_RDF_CANS]]:
+        for plotMode in [
+            plotMode for plotMode in PlotModes
+            if plotMode not in [
+                PlotModes.SF, PlotModes.SF_RDF,
+                PlotModes.SF_CANS, PlotModes.SF_RDF_CANS
+            ]
+        ]:
             self.mainWidget.allPlotComboBox.addItem(plotMode.name, plotMode)
 
         self.mainWidget.allPlotComboBox.currentIndexChanged.connect(
             self.handleAllPlotModeChanged
         )
 
-        for plotMode in [plotMode for plotMode in PlotModes if "(Cans)" not in plotMode.name]:
+        for plotMode in [
+            plotMode for plotMode in PlotModes
+            if "(Cans)" not in plotMode.name
+        ]:
             self.mainWidget.plotComboBox.addItem(plotMode.name, plotMode)
 
         self.mainWidget.plotComboBox.currentIndexChanged.connect(
             self.handleSamplePlotModeChanged
         )
 
-        for plotMode in [plotMode for plotMode in PlotModes if "(Cans)" in plotMode.name]:
-            self.mainWidget.containerPlotComboBox.addItem(plotMode.name, plotMode)
+        for plotMode in [
+            plotMode for plotMode in PlotModes if "(Cans)" in plotMode.name
+        ]:
+            self.mainWidget.containerPlotComboBox.addItem(
+                plotMode.name, plotMode
+            )
 
         self.mainWidget.containerPlotComboBox.currentIndexChanged.connect(
             self.handleContainerPlotModeChanged
@@ -688,9 +701,13 @@ class GudPyMainWindow(QMainWindow):
             )
             topChart.addSample(sample)
             if isinstance(sample, Sample):
-                topPlotMode = self.mainWidget.plotComboBox.itemData(self.mainWidget.plotComboBox.currentIndex())
+                topPlotMode = self.mainWidget.plotComboBox.itemData(
+                    self.mainWidget.plotComboBox.currentIndex()
+                )
             else:
-                topPlotMode = self.mainWidget.containerPlotComboBox.itemData(self.mainWidget.containerPlotComboBox.currentIndex())
+                topPlotMode = self.mainWidget.containerPlotComboBox.itemData(
+                    self.mainWidget.containerPlotComboBox.currentIndex()
+                )
             topChart.plot(topPlotMode)
             bottomChart = GudPyChart(
                 self.gudrunFile
@@ -721,7 +738,11 @@ class GudPyMainWindow(QMainWindow):
                 self.gudrunFile
             )
             allTopChart.addSamples(samples)
-            allTopChart.plot(self.mainWidget.allPlotComboBox.itemData(self.mainWidget.allPlotComboBox.currentIndex()))
+            allTopChart.plot(
+                self.mainWidget.allPlotComboBox.itemData(
+                    self.mainWidget.allPlotComboBox.currentIndex()
+                )
+            )
             allBottomChart = GudPyChart(
                 self.gudrunFile
             )
@@ -731,7 +752,11 @@ class GudPyMainWindow(QMainWindow):
                 self.gudrunFile
             )
             allTopChart.addSamples(samples)
-            allTopChart.plot(self.mainWidget.allPlotComboBox.itemData(self.mainWidget.allPlotComboBox.currentIndex()))
+            allTopChart.plot(
+                self.mainWidget.allPlotComboBox.itemData(
+                    self.mainWidget.allPlotComboBox.currentIndex()
+                )
+            )
             allBottomChart = GudPyChart(
                 self.gudrunFile
             )
@@ -1295,45 +1320,63 @@ class GudPyMainWindow(QMainWindow):
         plotMode = self.mainWidget.allPlotComboBox.itemData(index)
         if self.isPlotModeSplittable(plotMode):
             top, bottom = self.splitPlotMode(plotMode)
-            self.handlePlotModeChanged(self.mainWidget.allSampleTopPlot.chart().plot, top)
-            self.handlePlotModeChanged(self.mainWidget.allSampleBottomPlot.chart().plot, bottom)
+            self.handlePlotModeChanged(
+                self.mainWidget.allSampleTopPlot.chart().plot, top
+            )
+            self.handlePlotModeChanged(
+                self.mainWidget.allSampleBottomPlot.chart().plot, bottom
+            )
             self.mainWidget.bottomPlotFrame.setVisible(True)
-            self.mainWidget.allPlotSplitter.setSizes([1,1])
+            self.mainWidget.allPlotSplitter.setSizes([1, 1])
         else:
-            self.handlePlotModeChanged(self.mainWidget.allSampleTopPlot.chart().plot, plotMode)
+            self.handlePlotModeChanged(
+                self.mainWidget.allSampleTopPlot.chart().plot, plotMode
+            )
             self.mainWidget.bottomPlotFrame.setVisible(False)
-            self.mainWidget.allPlotSplitter.setSizes([1,0])
+            self.mainWidget.allPlotSplitter.setSizes([1, 0])
 
     def handleSamplePlotModeChanged(self, index):
         plotMode = self.mainWidget.plotComboBox.itemData(index)
         if self.isPlotModeSplittable(plotMode):
             top, bottom = self.splitPlotMode(plotMode)
-            self.handlePlotModeChanged(self.mainWidget.sampleTopPlot.chart().plot, top)
-            self.handlePlotModeChanged(self.mainWidget.sampleBottomPlot.chart().plot, bottom)
+            self.handlePlotModeChanged(
+                self.mainWidget.sampleTopPlot.chart().plot, top
+            )
+            self.handlePlotModeChanged(
+                self.mainWidget.sampleBottomPlot.chart().plot, bottom
+            )
             self.mainWidget.bottomSamplePlotFrame.setVisible(True)
-            self.mainWidget.samplePlotSplitter.setSizes([1,1])
+            self.mainWidget.samplePlotSplitter.setSizes([1, 1])
         else:
-            self.handlePlotModeChanged(self.mainWidget.sampleTopPlot.chart().plot, plotMode)
+            self.handlePlotModeChanged(
+                self.mainWidget.sampleTopPlot.chart().plot, plotMode
+            )
             self.mainWidget.bottomSamplePlotFrame.setVisible(False)
-            self.mainWidget.samplePlotSplitter.setSizes([1,0])
+            self.mainWidget.samplePlotSplitter.setSizes([1, 0])
 
     def handleContainerPlotModeChanged(self, index):
         plotMode = self.mainWidget.plotComboBox.itemData(index)
         if self.isPlotModeSplittable(plotMode):
             top, bottom = self.splitPlotMode(plotMode)
-            self.handlePlotModeChanged(self.mainWidget.containerTopPlot.chart().plot, top)
-            self.handlePlotModeChanged(self.mainWidget.containerBottomPlot.chart().plot, bottom)
+            self.handlePlotModeChanged(
+                self.mainWidget.containerTopPlot.chart().plot, top
+            )
+            self.handlePlotModeChanged(
+                self.mainWidget.containerBottomPlot.chart().plot, bottom
+            )
             self.mainWidget.bottomContainerPlotFrame.setVisible(True)
-            self.mainWidget.containerPlotSplitter.setSizes([1,1])
+            self.mainWidget.containerPlotSplitter.setSizes([1, 1])
         else:
-            self.handlePlotModeChanged(self.mainWidget.containerTopPlot.chart().plot, plotMode)
+            self.handlePlotModeChanged(
+                self.mainWidget.containerTopPlot.chart().plot, plotMode
+            )
             self.mainWidget.bottomContainerPlotFrame.setVisible(False)
-            self.mainWidget.containerPlotSplitter.setSizes([1,0])
+            self.mainWidget.containerPlotSplitter.setSizes([1, 0])
 
     @abstractmethod
     def isPlotModeSplittable(self, plotMode):
         return plotMode in SPLIT_PLOTS.keys()
-    
+
     @abstractmethod
     def splitPlotMode(self, plotMode):
         return SPLIT_PLOTS[plotMode]

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -767,12 +767,12 @@ class GudPyMainWindow(QMainWindow):
                 self.gudrunFile
             )
             topChart.addSample(sample)
-            topChart.plot(PlotModes.SF)
+            topChart.plot(self.mainWidget.topPlotComboBox.itemData(self.mainWidget.topPlotComboBox.currentIndex()))
             bottomChart = GudPyChart(
                 self.gudrunFile
             )
             bottomChart.addSample(sample)
-            bottomChart.plot(PlotModes.RDF)
+            bottomChart.plot(self.mainWidget.bottomPlotComboBox.itemData(self.mainWidget.bottomPlotComboBox.currentIndex()))
             path = None
             if len(sample.dataFiles.dataFiles):
                 path = breplace(
@@ -798,23 +798,23 @@ class GudPyMainWindow(QMainWindow):
                 self.gudrunFile
             )
             allTopChart.addSamples(samples)
-            allTopChart.plot(PlotModes.SF)
+            allTopChart.plot(self.mainWidget.topAllPlotComboBox.itemData(self.mainWidget.topAllPlotComboBox.currentIndex()))
             allBottomChart = GudPyChart(
                 self.gudrunFile
             )
             allBottomChart.addSamples(samples)
-            allBottomChart.plot(PlotModes.RDF)
+            allBottomChart.plot(self.mainWidget.bottomAllPlotComboBox.itemData(self.mainWidget.bottomAllPlotComboBox.currentIndex()))
         else:
             allTopChart = GudPyChart(
                 self.gudrunFile
             )
             allTopChart.addSamples(samples)
-            allTopChart.plot(PlotModes.SF)
+            allTopChart.plot(self.mainWidget.topAllPlotComboBox.itemData(self.mainWidget.topAllPlotComboBox.currentIndex()))
             allBottomChart = GudPyChart(
                 self.gudrunFile
             )
             allBottomChart.addSamples(samples)
-            allBottomChart.plot(PlotModes.RDF)
+            allBottomChart.plot(self.mainWidget.bottomAllPlotComboBox.itemData(self.mainWidget.bottomAllPlotComboBox.currentIndex()))
         self.allPlots = [allTopChart, allBottomChart]
         self.mainWidget.allSampleTopPlot.setChart(allTopChart)
         self.mainWidget.allSampleBottomPlot.setChart(allBottomChart)

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -48,7 +48,7 @@ from src.gui.widgets.exponential_spinbox import ExponentialSpinBox
 from src.gui.widgets.charts.chart import GudPyChart
 from src.gui.widgets.charts.chartview import GudPyChartView
 from src.gui.widgets.charts.beam_plot import BeamChart
-from src.gui.widgets.charts.enums import PlotModes, SPLIT_PLOTS
+from src.gui.widgets.charts.enums import PLOT_MODES, PlotModes, SPLIT_PLOTS
 
 from src.gudrun_classes.enums import Geometry
 from src.gui.widgets.slots.instrument_slots import InstrumentSlots
@@ -269,7 +269,7 @@ class GudPyMainWindow(QMainWindow):
 
         self.mainWidget.bottomPlotFrame.setVisible(False)
 
-        for plotMode in PlotModes:
+        for plotMode in [plotMode for plotMode in PlotModes if plotMode not in [PlotModes.SF, PlotModes.SF_RDF, PlotModes.SF_CANS, PlotModes.SF_RDF_CANS]]:
             self.mainWidget.allPlotComboBox.addItem(plotMode.name, plotMode)
 
         self.mainWidget.allPlotComboBox.currentIndexChanged.connect(
@@ -579,9 +579,9 @@ class GudPyMainWindow(QMainWindow):
             )
 
             plotsMap = {
-                PlotModes.SF_MINT01: 0,
-                PlotModes.SF_MDCS01: 1,
-                PlotModes.RDF: 0
+                PlotModes.SF: 0,
+                PlotModes.SF_MINT01: 1,
+                PlotModes.SF_MDCS01: 2,
             }
 
             self.mainWidget.plotComboBox.setCurrentIndex(

--- a/src/gui/widgets/ui_files/mainWindow.ui
+++ b/src/gui/widgets/ui_files/mainWindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1580</width>
-    <height>1450</height>
+    <height>1453</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -5992,37 +5992,32 @@
                    </widget>
                   </item>
                   <item>
-                   <widget class="QSplitter" name="splitter_3">
+                   <widget class="QSplitter" name="samplePlotSplitter">
                     <property name="orientation">
                      <enum>Qt::Vertical</enum>
                     </property>
-                    <widget class="QFrame" name="frame_2">
+                    <widget class="QFrame" name="topSamplePlotFrame">
                      <property name="frameShape">
                       <enum>QFrame::Box</enum>
                      </property>
                      <property name="frameShadow">
                       <enum>QFrame::Raised</enum>
                      </property>
-                     <layout class="QVBoxLayout" name="topPlotLayout">
-                      <item>
-                       <widget class="QComboBox" name="topPlotComboBox"/>
-                      </item>
-                     </layout>
+                     <layout class="QVBoxLayout" name="topPlotLayout"/>
                     </widget>
-                    <widget class="QFrame" name="frame_3">
+                    <widget class="QFrame" name="bottomSamplePlotFrame">
                      <property name="frameShape">
                       <enum>QFrame::Box</enum>
                      </property>
                      <property name="frameShadow">
                       <enum>QFrame::Raised</enum>
                      </property>
-                     <layout class="QVBoxLayout" name="bottomPlotLayout">
-                      <item>
-                       <widget class="QComboBox" name="bottomPlotComboBox"/>
-                      </item>
-                     </layout>
+                     <layout class="QVBoxLayout" name="bottomPlotLayout"/>
                     </widget>
                    </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="plotComboBox"/>
                   </item>
                  </layout>
                 </widget>
@@ -7118,37 +7113,32 @@
                    </widget>
                   </item>
                   <item>
-                   <widget class="QSplitter" name="splitter_4">
+                   <widget class="QSplitter" name="containerPlotSplitter">
                     <property name="orientation">
                      <enum>Qt::Vertical</enum>
                     </property>
-                    <widget class="QFrame" name="frame_7">
+                    <widget class="QFrame" name="topContainerPlotFrame">
                      <property name="frameShape">
                       <enum>QFrame::Box</enum>
                      </property>
                      <property name="frameShadow">
                       <enum>QFrame::Raised</enum>
                      </property>
-                     <layout class="QVBoxLayout" name="topContainerPlotLayout">
-                      <item>
-                       <widget class="QComboBox" name="topContainerPlotComboBox"/>
-                      </item>
-                     </layout>
+                     <layout class="QVBoxLayout" name="topContainerPlotLayout"/>
                     </widget>
-                    <widget class="QFrame" name="frame_10">
+                    <widget class="QFrame" name="bottomContainerPlotFrame">
                      <property name="frameShape">
                       <enum>QFrame::Box</enum>
                      </property>
                      <property name="frameShadow">
                       <enum>QFrame::Raised</enum>
                      </property>
-                     <layout class="QVBoxLayout" name="bottomContainerPlotLayout">
-                      <item>
-                       <widget class="QComboBox" name="bottomContainerPlotComboBox"/>
-                      </item>
-                     </layout>
+                     <layout class="QVBoxLayout" name="bottomContainerPlotLayout"/>
                     </widget>
                    </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="containerPlotComboBox"/>
                   </item>
                  </layout>
                 </widget>
@@ -7168,85 +7158,56 @@
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_3">
         <item>
-         <widget class="QSplitter" name="splitter_2">
+         <widget class="QSplitter" name="allPlotSplitter">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
           </property>
-          <widget class="QFrame" name="frame_8">
+          <widget class="QFrame" name="topPlotFrame">
            <property name="frameShape">
             <enum>QFrame::Box</enum>
            </property>
            <property name="frameShadow">
             <enum>QFrame::Raised</enum>
            </property>
-           <layout class="QVBoxLayout" name="topAllPlotLayout">
-            <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_85">
-              <item>
-               <widget class="QComboBox" name="topAllPlotComboBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="horizontalSpacer_38">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </item>
-           </layout>
+           <layout class="QVBoxLayout" name="topAllPlotLayout"/>
           </widget>
-          <widget class="QFrame" name="frame_9">
+          <widget class="QFrame" name="bottomPlotFrame">
            <property name="frameShape">
             <enum>QFrame::Box</enum>
            </property>
            <property name="frameShadow">
             <enum>QFrame::Raised</enum>
            </property>
-           <layout class="QVBoxLayout" name="bottomAllPlotLayout">
-            <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_86">
-              <item>
-               <widget class="QComboBox" name="bottomAllPlotComboBox">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer name="horizontalSpacer_39">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-             </layout>
-            </item>
-           </layout>
+           <layout class="QVBoxLayout" name="bottomAllPlotLayout"/>
           </widget>
          </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_99">
+          <item>
+           <widget class="QComboBox" name="allPlotComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_38">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>


### PR DESCRIPTION
PR to fix up some charting issues and inconveniences.

- No longer plot mint01 and mdcs01 files together, with the expected DCS level on the summary page. Only do this for individual samples/containers. Closes #290.
- Fix bug with incorrect plot mode being shown after running gudrun_dcs - where the plot mode displayed doesn't match the combo box. Closes #295.
- Optionally split Structure Factor / RDF, rather than by default. Closes #292.
- Also, show co-ordinates in the chart of the mouse. Closes #293.
