### PR TITLE
Iteration fixes

### DIFF
--- a/src/gudrun_classes/tweak_factor_iterator.py
+++ b/src/gudrun_classes/tweak_factor_iterator.py
@@ -1,5 +1,7 @@
 from src.gudrun_classes.gud_file import GudFile
 import os
+import time
+from copy import deepcopy
 
 
 class TweakFactorIterator():
@@ -32,7 +34,7 @@ class TweakFactorIterator():
         gudrunFile : GudrunFile
             Input GudrunFile that we will be using for iterating.
         """
-        self.gudrunFile = gudrunFile
+        self.gudrunFile = deepcopy(gudrunFile)
 
     def performIteration(self, _n):
         # Iterate through all samples,
@@ -81,4 +83,5 @@ class TweakFactorIterator():
             # Write out what we currently have,
             # and run gudrun_dcs on that file.
             self.gudrunFile.process()
+            time.sleep(1)
             self.performIteration(i)

--- a/src/gudrun_classes/wavelength_subtraction_iterator.py
+++ b/src/gudrun_classes/wavelength_subtraction_iterator.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 from src.gudrun_classes.enums import Scales
+import time
+from copy import deepcopy
 
 
 class WavelengthSubtractionIterator():
@@ -64,7 +66,7 @@ class WavelengthSubtractionIterator():
         gudrunFile : GudrunFile
             Input GudrunFile that we will be using for iterating.
         """
-        self.gudrunFile = gudrunFile
+        self.gudrunFile = deepcopy(gudrunFile)
         self.topHatWidths = []
         self.QMax = 0.
         self.QMin = 0.
@@ -251,5 +253,7 @@ class WavelengthSubtractionIterator():
 
             self.wavelengthIteration(i)
             self.gudrunFile.process()
+            time.sleep(1)
             self.QIteration(i)
             self.gudrunFile.process()
+            time.sleep(1)

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -77,6 +77,7 @@ from src.scripts.utils import breplace, nthint
 
 import os
 import sys
+import time
 import math
 import traceback
 from queue import Queue
@@ -1039,9 +1040,11 @@ class GudPyMainWindow(QMainWindow):
         if self.error:
             self.proc.finished.connect(self.procFinished)
         if isinstance(self.iterator, TweakFactorIterator):
+            time.sleep(1)
             self.iterator.performIteration(self.currentIteration)
             self.gudrunFile.write_out()
         elif isinstance(self.iterator, WavelengthSubtractionIterator):
+            time.sleep(1)
             if (self.currentIteration + 1) % 2 == 0:
                 self.iterator.QIteration(self.currentIteration)
             else:


### PR DESCRIPTION
Minor PR to fix some iteration related problems.

- Sleep between iterations to try and ensure that files required to be read from are 'ready'. Closes #303.
- Use a deepcopy of the GudrunFile object to iterate on - to prevent intermediate changes whilst iterating to be applied to the reference GudrunFile object. Closes #304.