### PR TITLE
Safe Matching

### DIFF
--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -406,33 +406,45 @@ class GudrunFile:
             # First construct the regular expression to match against.
             pattern = re.compile(r"StartupFiles\S*")
 
-            self.instrument.detectorCalibrationFileName = (
-                re.search(
-                    pattern,
-                    self.instrument.detectorCalibrationFileName
-                ).group()
+            match = re.search(
+                pattern,
+                self.instrument.detectorCalibrationFileName
             )
 
-            self.instrument.groupFileName = (
-                re.search(
+            if match:
+                self.instrument.detectorCalibrationFileName = match.group()
+
+            match = re.search(
                     pattern,
                     self.instrument.groupFileName
-                ).group()
             )
+            
+            if match:
+                self.instrument.groupFileName = match.group()
 
-            self.instrument.deadtimeConstantsFileName = (
-                re.search(
+            match = re.search(
                     pattern,
                     self.instrument.deadtimeConstantsFileName
-                ).group()
             )
+            
+            if match:
+                self.instrument.deadtimeConstantsFileName = match.group()
 
-            self.instrument.neutronScatteringParametersFile = (
-                re.search(
+            match = re.search(
                     pattern,
                     self.instrument.neutronScatteringParametersFile
-                ).group()
             )
+
+            if match:
+                self.instrument.neutronScatteringParametersFile = match.group()
+            
+            match = re.search(
+                    pattern,
+                    self.instrument.neutronScatteringParametersFile
+            )
+
+            if match:
+                self.instrument.neutronScatteringParametersFile = match.group()
 
         except Exception as e:
             raise ParserException(
@@ -518,12 +530,13 @@ class GudrunFile:
             # to resolve the path to be relative.
             pattern = re.compile(r"StartupFiles\S*")
 
-            self.beam.filenameIncidentBeamSpectrumParams = (
-                re.search(
+            match = re.search(
                     pattern,
                     self.beam.filenameIncidentBeamSpectrumParams
-                ).group()
             )
+
+            if match:
+                self.beam.filenameIncidentBeamSpectrumParams = match.group()
 
             self.beam.overallBackgroundFactor = (
                 nthfloat(self.getNextToken(), 0)
@@ -722,24 +735,23 @@ class GudrunFile:
             # Consume whitespace and the closing brace.
             self.consumeUpToDelim("}")
 
-            if (
-                '*' not in
-                self.normalisation.normalisationDifferentialCrossSectionFile
-            ):
-                # Resolve to relative.
-                pattern = re.compile(r"StartupFiles\S*")
+
+            # Resolve to relative.
+            pattern = re.compile(r"StartupFiles\S*")
+
+            match = re.search(
+                pattern,
+                self.normalisation.
+                normalisationDifferentialCrossSectionFile
+            )
+
+            if match:
+                self.normalisation
+
                 (
                     self.normalisation.
                     normalisationDifferentialCrossSectionFile
-                ) = (
-                    re.search(
-                        pattern,
-                        (
-                            self.normalisation.
-                            normalisationDifferentialCrossSectionFile
-                        )
-                    ).group()
-                )
+                ) = match.group()
 
         except Exception as e:
             raise ParserException(

--- a/src/gudrun_classes/gudrun_file.py
+++ b/src/gudrun_classes/gudrun_file.py
@@ -418,7 +418,7 @@ class GudrunFile:
                     pattern,
                     self.instrument.groupFileName
             )
-            
+
             if match:
                 self.instrument.groupFileName = match.group()
 
@@ -426,7 +426,7 @@ class GudrunFile:
                     pattern,
                     self.instrument.deadtimeConstantsFileName
             )
-            
+
             if match:
                 self.instrument.deadtimeConstantsFileName = match.group()
 
@@ -437,7 +437,7 @@ class GudrunFile:
 
             if match:
                 self.instrument.neutronScatteringParametersFile = match.group()
-            
+
             match = re.search(
                     pattern,
                     self.instrument.neutronScatteringParametersFile
@@ -734,7 +734,6 @@ class GudrunFile:
 
             # Consume whitespace and the closing brace.
             self.consumeUpToDelim("}")
-
 
             # Resolve to relative.
             pattern = re.compile(r"StartupFiles\S*")


### PR DESCRIPTION
PR to make matching using regex safe when parsing an input file. This solves a problem that occurs when one of the various configuration files are not present in the `StartupFiles` directory (hence, closes #314).