### PR TITLE
Run Gudrun after Purging

### DIFF
--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -1018,8 +1018,8 @@ class GudPyMainWindow(QMainWindow):
                     self.mainWidget,
                     "GudPy Error", "Couldn't find purge_det binary."
                 )
-            self.setControlsEnabled(True)
-            return
+                self.setControlsEnabled(True)
+                return
         else:
             self.runPurge_()
         dcs = self.gudrunFile.dcs(
@@ -1036,6 +1036,7 @@ class GudPyMainWindow(QMainWindow):
                 self.mainWidget, "GudPy Error",
                 "Couldn't find gudrun_dcs binary."
             )
+            self.setControlsEnabled(True)
             return
         self.queue.put((dcs, self.progressDCS, func, args))
 

--- a/src/gui/widgets/main_window.py
+++ b/src/gui/widgets/main_window.py
@@ -1496,8 +1496,6 @@ class GudPyMainWindow(QMainWindow):
             self.error = ""
             self.queue = Queue()
         if not self.queue.empty():
-            self.makeProc(*self.queue.get())
-        else:
             if self.warning:
                 QMessageBox.warning(
                     self.mainWidget, "GudPy Warning",
@@ -1521,6 +1519,8 @@ class GudPyMainWindow(QMainWindow):
         self.output = ""
         self.mainWidget.currentTaskLabel.setText("No task running.")
         self.mainWidget.progressBar.setValue(0)
+        if not self.queue.empty():
+            self.makeProc(*self.queue.get())
 
     def viewInput(self):
         self.currentState = str(self.gudrunFile)


### PR DESCRIPTION
Small PR which fixes bug described in #320.

gudrun_dcs is automatically run after a purge is performed, when the purge was executed via a prompt (i.e. the prompt which suggests that detectors have not yet been purged).

Closes #320.