### PR TITLE
Display Packing Fraction

### DIFF
--- a/gudpy/gui/widgets/slots/container_slots.py
+++ b/gudpy/gui/widgets/slots/container_slots.py
@@ -90,15 +90,18 @@ class ContainerSlots():
         self.widget.containerCrossSectionFileWidget.setVisible(
             self.container.totalCrossSectionSource == CrossSectionSource.FILE
         )
-        # Set the tweak factor and packing fraction (reciprocal of tweak factor).
+        # Set the tweak factor and packing fraction
+        # (reciprocal of tweak factor).
         self.widget.containerTweakFactorSpinBox.setValue(
             self.container.tweakFactor
         )
         if self.container.tweakFactor > 0.0:
-            self.widget.containerPackingFractionSpinBox.setValue(1.0 / self.container.tweakFactor)
+            self.widget.containerPackingFractionSpinBox.setValue(
+                1.0 / self.container.tweakFactor
+            )
         else:
             self.widget.containerPackingFractionSpinBox.setValue(0.0)
-        
+
         self.packingFractionChanging = False
 
         self.widget.containerScatteringFractionSpinBox.setValue(

--- a/gudpy/gui/widgets/slots/container_slots.py
+++ b/gudpy/gui/widgets/slots/container_slots.py
@@ -90,9 +90,16 @@ class ContainerSlots():
         self.widget.containerCrossSectionFileWidget.setVisible(
             self.container.totalCrossSectionSource == CrossSectionSource.FILE
         )
+        # Set the tweak factor and packing fraction (reciprocal of tweak factor).
         self.widget.containerTweakFactorSpinBox.setValue(
             self.container.tweakFactor
         )
+        if self.container.tweakFactor > 0.0:
+            self.widget.containerPackingFractionSpinBox.setValue(1.0 / self.container.tweakFactor)
+        else:
+            self.widget.containerPackingFractionSpinBox.setValue(0.0)
+        
+        self.packingFractionChanging = False
 
         self.widget.containerScatteringFractionSpinBox.setValue(
             self.container.scatteringFraction
@@ -234,6 +241,11 @@ class ContainerSlots():
         self.widget.containerTweakFactorSpinBox.valueChanged.connect(
             self.handleTweakFactorChanged
         )
+
+        self.widget.containerPackingFractionSpinBox.valueChanged.connect(
+            self.handlePackingFractionChanged
+        )
+
         self.widget.containerScatteringFractionSpinBox.valueChanged.connect(
             self.handleScatteringFractionChanged
         )
@@ -456,15 +468,39 @@ class ContainerSlots():
         Slot for handling change in the sample tweak factor.
         Called when a valueChanged signal is emitted,
         from the containerTweakFactorSpinBox.
-        Alters the container's density as such.
+        Alters the container's tweak factor as such.
         Parameters
         ----------
         value : float
             The new value of the containerTweakFactorSpinBox.
         """
         self.container.tweakFactor = value
+        self.packingFractionChanging = True
+        if value > 0.0:
+            self.widget.containerPackingFractionSpinBox.setValue(1.0 / value)
+        else:
+            self.widget.containerPackingFractionSpinBox.setValue(0.0)
+        self.packingFractionChanging = False
         if not self.widgetsRefreshing:
             self.parent.setModified()
+
+    def handlePackingFractionChanged(self, value):
+        """
+        Slot for handling change in the packing fraction.
+        Called when a valueChanged signal is emitted,
+        from the the containerPackingFractionSpinBox.
+        Updates the containers's tweak factor to reflect
+        the new packing fraction.
+        Parameters
+        ----------
+        value : float
+            The new current value of the containerPackingFractionSpinBox.
+        """
+        if not self.packingFractionChanging:
+            if value > 0.0:
+                self.widget.containerTweakFactorSpinBox.setValue(1.0 / value)
+            else:
+                self.widget.containerTweakFactorSpinBox.setValue(0.0)
 
     def handleAngleOfRotationChanged(self, value):
         """

--- a/gudpy/gui/widgets/slots/sample_slots.py
+++ b/gudpy/gui/widgets/slots/sample_slots.py
@@ -103,6 +103,14 @@ class SampleSlots():
         # Populate the tweak factor.
         self.widget.tweakFactorSpinBox.setValue(self.sample.sampleTweakFactor)
 
+        # Populate the packing fraction.
+        if self.sample.sampleTweakFactor > 0.0:
+            self.widget.packingFractionSpinBox.setValue(1.0 / self.sample.sampleTweakFactor)
+        else:
+            self.widget.packingFractionSpinBox.setValue(0.0)
+
+        self.packingFractionChanging = False
+
         # Populate Fourier Transform parameters.
         self.widget.topHatWidthSpinBox.setValue(self.sample.topHatW)
 
@@ -273,6 +281,11 @@ class SampleSlots():
         # Setup slot for tweak factor.
         self.widget.tweakFactorSpinBox.valueChanged.connect(
             self.handleTweakFactorChanged
+        )
+
+        # Setup slot for packing fraction
+        self.widget.packingFractionSpinBox.valueChanged.connect(
+            self.handlePackingFractionChanged
         )
 
         # Setup slots for Fourier Transform parameters.
@@ -558,14 +571,39 @@ class SampleSlots():
         Called when a valueChanged signal is emitted,
         from the the tweakFactorSpinBox.
         Alters the sample's tweak factor as such.
+        Also updates the packing fraction.
         Parameters
         ----------
         value : float
             The new current value of the tweakFactorSpinBox.
         """
         self.sample.sampleTweakFactor = value
+        self.packingFractionChanging = True
+        if value > 0.0:
+            self.widget.packingFractionSpinBox.setValue(1.0 / value)
+        else:
+            self.widget.packingFractionSpinBox.setValue(0.0)
+        self.packingFractionChanging = False
         if not self.widgetsRefreshing:
             self.parent.setModified()
+
+    def handlePackingFractionChanged(self, value):
+        """
+        Slot for handling change in the sample packing fraction.
+        Called when a valueChanged signal is emitted,
+        from the the packingFractionSpinBox.
+        Updates the sample's tweak factor to reflect
+        the new packing fraction.
+        Parameters
+        ----------
+        value : float
+            The new current value of the packingFractionSpinBox.
+        """
+        if not self.packingFractionChanging:
+            if value > 0.0:
+                self.widget.tweakFactorSpinBox.setValue(1.0 / value)
+            else:
+                self.widget.tweakFactorSpinBox.setValue(0.0)
 
     def handleTopHatWidthChanged(self, value):
         """

--- a/gudpy/gui/widgets/slots/sample_slots.py
+++ b/gudpy/gui/widgets/slots/sample_slots.py
@@ -103,7 +103,7 @@ class SampleSlots():
         # Populate the tweak factor.
         self.widget.tweakFactorSpinBox.setValue(self.sample.sampleTweakFactor)
 
-        # Populate the packing fraction.
+        # Populate the packing fraction (reciprocal of tweak factor).
         if self.sample.sampleTweakFactor > 0.0:
             self.widget.packingFractionSpinBox.setValue(1.0 / self.sample.sampleTweakFactor)
         else:

--- a/gudpy/gui/widgets/slots/sample_slots.py
+++ b/gudpy/gui/widgets/slots/sample_slots.py
@@ -105,7 +105,9 @@ class SampleSlots():
 
         # Populate the packing fraction (reciprocal of tweak factor).
         if self.sample.sampleTweakFactor > 0.0:
-            self.widget.packingFractionSpinBox.setValue(1.0 / self.sample.sampleTweakFactor)
+            self.widget.packingFractionSpinBox.setValue(
+                1.0 / self.sample.sampleTweakFactor
+            )
         else:
             self.widget.packingFractionSpinBox.setValue(0.0)
 

--- a/gudpy/gui/widgets/ui_files/mainWindow.ui
+++ b/gudpy/gui/widgets/ui_files/mainWindow.ui
@@ -4866,6 +4866,20 @@
                             </property>
                            </widget>
                           </item>
+                          <item>
+                           <widget class="QLabel" name="label_7">
+                            <property name="text">
+                             <string>Packing Fraction</string>
+                            </property>
+                           </widget>
+                          </item>
+                          <item>
+                           <widget class="ExponentialSpinBox" name="packingFractionSpinBox">
+                            <property name="maximum">
+                             <double>1000.000000000000000</double>
+                            </property>
+                           </widget>
+                          </item>
                          </layout>
                         </item>
                         <item>
@@ -5914,7 +5928,6 @@
                         <widget class="QLabel" name="expectedDcsLabel">
                          <property name="font">
                           <font>
-                           <weight>75</weight>
                            <bold>true</bold>
                           </font>
                          </property>
@@ -5933,7 +5946,6 @@
                         <widget class="QLabel" name="dcsLabel">
                          <property name="font">
                           <font>
-                           <weight>75</weight>
                            <bold>true</bold>
                           </font>
                          </property>
@@ -5952,7 +5964,6 @@
                         <widget class="QLabel" name="resultLabel">
                          <property name="font">
                           <font>
-                           <weight>75</weight>
                            <bold>true</bold>
                           </font>
                          </property>
@@ -5973,7 +5984,6 @@
                       <widget class="QLabel" name="suggestedTweakFactorLabel">
                        <property name="font">
                         <font>
-                         <weight>75</weight>
                          <bold>true</bold>
                         </font>
                        </property>
@@ -7035,7 +7045,6 @@
                         <widget class="QLabel" name="containerExpectedDcsLabel">
                          <property name="font">
                           <font>
-                           <weight>75</weight>
                            <bold>true</bold>
                           </font>
                          </property>
@@ -7054,7 +7063,6 @@
                         <widget class="QLabel" name="containerDcsLabel">
                          <property name="font">
                           <font>
-                           <weight>75</weight>
                            <bold>true</bold>
                           </font>
                          </property>
@@ -7073,7 +7081,6 @@
                         <widget class="QLabel" name="containerResultLabel">
                          <property name="font">
                           <font>
-                           <weight>75</weight>
                            <bold>true</bold>
                           </font>
                          </property>
@@ -7094,7 +7101,6 @@
                       <widget class="QLabel" name="containerSuggestedTweakFactorLabel">
                        <property name="font">
                         <font>
-                         <weight>75</weight>
                          <bold>true</bold>
                         </font>
                        </property>

--- a/gudpy/gui/widgets/ui_files/mainWindow.ui
+++ b/gudpy/gui/widgets/ui_files/mainWindow.ui
@@ -6579,17 +6579,24 @@
                           </widget>
                          </item>
                          <item>
-                          <spacer name="horizontalSpacer_35">
-                           <property name="orientation">
-                            <enum>Qt::Horizontal</enum>
+                          <widget class="QLabel" name="label_8">
+                           <property name="text">
+                            <string>Packing Fraction</string>
                            </property>
-                           <property name="sizeHint" stdset="0">
-                            <size>
-                             <width>40</width>
-                             <height>20</height>
-                            </size>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="ExponentialSpinBox" name="containerPackingFractionSpinBox">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
                            </property>
-                          </spacer>
+                           <property name="maximum">
+                            <double>1000.000000000000000</double>
+                           </property>
+                          </widget>
                          </item>
                         </layout>
                        </item>


### PR DESCRIPTION
This PR potentially solves one of the original "issues" - #8. Whilst renaming the 'tweak factor' to 'packing fraction', and performing calculations during reading/writing etc. could be potentially dangerous, with newer/older input file formats, it doesn't do any harm to simply display the packing fraction. Hence, this PR implements an extra exponential spin box next to the Tweak Factor (for both samples and containers), this is updated as the tweak factor changes, and vice versa - however, the packing fraction is not stored as a class attribute.

This is just an idea - and certainly does not need to be merged in, if it's not an appropriate enhancement.

Closes #8.