### PR TITLE
Mutable data files

### DIFF
--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -77,6 +77,7 @@ from gui.widgets.tables.exponential_table import ExponentialTable
 from gui.widgets.tables.resonance_table import ResonanceTable
 from gui.widgets.tables.components_table import ComponentsList
 from gui.widgets.core.exponential_spinbox import ExponentialSpinBox
+from gui.widgets.tables.data_file_list import DataFilesList
 from gui.widgets.charts.chart import GudPyChart
 from gui.widgets.charts.chartview import GudPyChartView
 from gui.widgets.charts.beam_plot import BeamChart
@@ -196,6 +197,7 @@ class GudPyMainWindow(QMainWindow):
         loader.registerCustomWidget(RatioCompositionTable)
         loader.registerCustomWidget(ExponentialTable)
         loader.registerCustomWidget(ResonanceTable)
+        loader.registerCustomWidget(DataFilesList)
         loader.registerCustomWidget(ComponentsList)
         loader.registerCustomWidget(CompositionIterationDialog)
         loader.registerCustomWidget(DensityIterationDialog)
@@ -676,7 +678,7 @@ class GudPyMainWindow(QMainWindow):
             self.mainWidget.geometryInfoStack.setCurrentIndex(
                 config.geometry.value
             )
-            self.widgetsRefreshing = False
+            self.normalisationSlots.widgetsRefreshing = False
         for i, sampleBackground in enumerate(
             self.gudrunFile.sampleBackgrounds
         ):

--- a/gudpy/gui/widgets/slots/container_slots.py
+++ b/gudpy/gui/widgets/slots/container_slots.py
@@ -25,10 +25,16 @@ class ContainerSlots():
         )
 
         # Populate the data files list.
-        self.widget.containerDataFilesList.makeModel(self.container.dataFiles.dataFiles)
+        self.widget.containerDataFilesList.makeModel(
+            self.container.dataFiles.dataFiles
+        )
 
-        self.widget.containerDataFilesList.model().dataChanged.connect(self.handleDataFilesAltered)
-        self.widget.containerDataFilesList.model().rowsRemoved.connect(self.handleDataFilesAltered)
+        self.widget.containerDataFilesList.model().dataChanged.connect(
+            self.handleDataFilesAltered
+        )
+        self.widget.containerDataFilesList.model().rowsRemoved.connect(
+            self.handleDataFilesAltered
+        )
 
         # Populate geometry data.
         self.widget.containerGeometryComboBox.setCurrentIndex(
@@ -606,7 +612,9 @@ class ContainerSlots():
         if not self.widgetsRefreshing:
             self.parent.setModified()
             self.parent.gudrunFile.purged = False
-            self.container.dataFiles.dataFiles = self.widget.containerDataFilesList.model().stringList()
+            self.container.dataFiles.dataFiles = (
+                self.widget.containerDataFilesList.model().stringList()
+            )
 
     def addFiles(self, target, title, regex):
         """

--- a/gudpy/gui/widgets/slots/container_slots.py
+++ b/gudpy/gui/widgets/slots/container_slots.py
@@ -173,6 +173,10 @@ class ContainerSlots():
             )
         )
 
+        self.widget.duplicateContainerDataFileButton.clicked.connect(
+            self.widget.containerDataFilesList.duplicate
+        )
+
         # Populate geometry combo box.
         for g in Geometry:
             self.widget.containerGeometryComboBox.addItem(g.name, g)

--- a/gudpy/gui/widgets/slots/normalisation_slots.py
+++ b/gudpy/gui/widgets/slots/normalisation_slots.py
@@ -6,6 +6,7 @@ from core.enums import (
 )
 from core import config
 
+
 class NormalisationSlots():
 
     def __init__(self, widget, parent):
@@ -17,14 +18,26 @@ class NormalisationSlots():
         self.normalisation = normalisation
         self.widgetsRefreshing = True
 
-        self.widget.dataFilesList.makeModel(self.normalisation.dataFiles.dataFiles)
-        self.widget.backgroundDataFilesList.makeModel(self.normalisation.dataFilesBg.dataFiles)
+        self.widget.dataFilesList.makeModel(
+            self.normalisation.dataFiles.dataFiles
+        )
+        self.widget.backgroundDataFilesList.makeModel(
+            self.normalisation.dataFilesBg.dataFiles
+        )
 
-        self.widget.dataFilesList.model().dataChanged.connect(self.handleDataFilesAltered)
-        self.widget.dataFilesList.model().rowsRemoved.connect(self.handleDataFilesAltered)
+        self.widget.dataFilesList.model().dataChanged.connect(
+            self.handleDataFilesAltered
+        )
+        self.widget.dataFilesList.model().rowsRemoved.connect(
+            self.handleDataFilesAltered
+        )
 
-        self.widget.backgroundDataFilesList.model().dataChanged.connect(self.handleDataFilesBgAltered)
-        self.widget.backgroundDataFilesList.model().rowsRemoved.connect(self.handleDataFilesBgAltered)
+        self.widget.backgroundDataFilesList.model().dataChanged.connect(
+            self.handleDataFilesBgAltered
+        )
+        self.widget.backgroundDataFilesList.model().rowsRemoved.connect(
+            self.handleDataFilesBgAltered
+        )
 
         self.widget.periodNoSpinBox.setValue(self.normalisation.periodNumber)
         self.widget.backgroundPeriodNoSpinBox.setValue(
@@ -636,7 +649,9 @@ class NormalisationSlots():
         if not self.widgetsRefreshing:
             self.parent.setModified()
             self.parent.gudrunFile.purged = False
-            self.normalisation.dataFiles.dataFiles = self.widget.dataFilesList.model().stringList()
+            self.normalisation.dataFiles.dataFiles = (
+                self.widget.dataFilesList.model().stringList()
+            )
 
     def handleDataFilesBgAltered(self):
         """
@@ -652,7 +667,9 @@ class NormalisationSlots():
         if not self.widgetsRefreshing:
             self.parent.setModified()
             self.parent.gudrunFile.purged = False
-            self.normalisation.dataFilesBg.dataFiles = self.widget.backgroundDataFilesList.model().stringList()
+            self.normalisation.dataFilesBg.dataFiles = (
+                self.widget.backgroundDataFilesList.model().stringList()
+            )
 
     def addFiles(self, target, title, regex):
         """

--- a/gudpy/gui/widgets/slots/normalisation_slots.py
+++ b/gudpy/gui/widgets/slots/normalisation_slots.py
@@ -125,6 +125,12 @@ class NormalisationSlots():
             )
         )
 
+        self.widget.duplicateDataFileButton.clicked.connect(
+            lambda: self.duplicateDataFile(
+                self.widget.dataFilesList
+            )
+        )
+
         self.widget.addBackgroundDataFileButton.clicked.connect(
             lambda: self.addDataFiles(
                 self.widget.backgroundDataFilesList,
@@ -136,6 +142,12 @@ class NormalisationSlots():
 
         self.widget.removeBackgroundDataFileButton.clicked.connect(
             lambda: self.removeDataFile(
+                self.widget.backgroundDataFilesList
+            )
+        )
+
+        self.widget.duplicateBackgroundDataFileButton.clicked.connect(
+            lambda: self.duplicateDataFile(
                 self.widget.backgroundDataFilesList
             )
         )
@@ -700,6 +712,9 @@ class NormalisationSlots():
 
     def removeDataFile(self, target):
         target.removeItem()
+
+    def duplicateDataFile(self, target):
+        target.duplicate()
 
     def updateCompositionTable(self):
         """

--- a/gudpy/gui/widgets/slots/normalisation_slots.py
+++ b/gudpy/gui/widgets/slots/normalisation_slots.py
@@ -6,7 +6,6 @@ from core.enums import (
 )
 from core import config
 
-
 class NormalisationSlots():
 
     def __init__(self, widget, parent):
@@ -16,12 +15,16 @@ class NormalisationSlots():
 
     def setNormalisation(self, normalisation):
         self.normalisation = normalisation
-
         self.widgetsRefreshing = True
 
-        self.updateDataFilesList()
+        self.widget.dataFilesList.makeModel(self.normalisation.dataFiles.dataFiles)
+        self.widget.backgroundDataFilesList.makeModel(self.normalisation.dataFilesBg.dataFiles)
 
-        self.updateBgDataFilesList()
+        self.widget.dataFilesList.model().dataChanged.connect(self.handleDataFilesAltered)
+        self.widget.dataFilesList.model().rowsRemoved.connect(self.handleDataFilesAltered)
+
+        self.widget.backgroundDataFilesList.model().dataChanged.connect(self.handleDataFilesBgAltered)
+        self.widget.backgroundDataFilesList.model().rowsRemoved.connect(self.handleDataFilesBgAltered)
 
         self.widget.periodNoSpinBox.setValue(self.normalisation.periodNumber)
         self.widget.backgroundPeriodNoSpinBox.setValue(
@@ -107,13 +110,6 @@ class NormalisationSlots():
         self.widgetsRefreshing = False
 
     def setupNormalisationSlots(self):
-        self.widget.dataFilesList.itemChanged.connect(
-            self.handleDataFilesAltered
-        )
-        self.widget.dataFilesList.itemEntered.connect(
-            self.handleDataFileInserted
-        )
-
         self.widget.addDataFileButton.clicked.connect(
             lambda: self.addDataFiles(
                 self.widget.dataFilesList,
@@ -125,30 +121,22 @@ class NormalisationSlots():
 
         self.widget.removeDataFileButton.clicked.connect(
             lambda: self.removeDataFile(
-                self.widget.dataFilesList, self.normalisation.dataFiles
+                self.widget.dataFilesList
             )
         )
 
-        self.widget.backgroundDataFilesList.itemChanged.connect(
-            self.handleBgDataFilesAltered
-        )
-        self.widget.backgroundDataFilesList.itemEntered.connect(
-            self.handleBgDataFileInserted
-        )
-
         self.widget.addBackgroundDataFileButton.clicked.connect(
-            lambda: self.addBgDataFiles(
+            lambda: self.addDataFiles(
                 self.widget.backgroundDataFilesList,
-                "Add background data files",
+                "Add data files",
                 f"{self.parent.gudrunFile.instrument.dataFileType}"
                 f" (*.{self.parent.gudrunFile.instrument.dataFileType})",
             )
         )
 
         self.widget.removeBackgroundDataFileButton.clicked.connect(
-            lambda: self.removeBgDataFile(
-                self.widget.backgroundDataFilesList,
-                self.normalisation.dataFilesBg
+            lambda: self.removeDataFile(
+                self.widget.backgroundDataFilesList
             )
         )
 
@@ -622,7 +610,7 @@ class NormalisationSlots():
         if not self.widgetsRefreshing:
             self.parent.setModified()
 
-    def handleDataFilesAltered(self, item):
+    def handleDataFilesAltered(self):
         """
         Slot for handling an item in the data files list being changed.
         Called when an itemChanged signal is emitted,
@@ -633,89 +621,26 @@ class NormalisationSlots():
         item : QListWidgetItem
             The item altered.
         """
-        index = item.row()
-        value = item.text()
-        if not value:
-            self.normalisation.dataFiles.dataFiles.remove(index)
-        else:
-            self.normalisation.dataFiles[index] = value
-        self.updateDataFilesList()
         if not self.widgetsRefreshing:
             self.parent.setModified()
             self.parent.gudrunFile.purged = False
+            self.normalisation.dataFiles.dataFiles = self.widget.dataFilesList.model().stringList()
 
-    def handleDataFileInserted(self, item):
+    def handleDataFilesBgAltered(self):
         """
-        Slot for handling an item in the data files list being entered.
-        Called when an itemEntered signal is emitted,
+        Slot for handling an item in the data files list being changed.
+        Called when an itemChanged signal is emitted,
         from the dataFilesList.
         Alters the normalisation's data files as such.
         Parameters
         ----------
         item : QListWidgetItem
-            The item entered.
+            The item altered.
         """
-        value = item.text()
-        self.normalisation.dataFiles.dataFiles.append(value)
         if not self.widgetsRefreshing:
             self.parent.setModified()
             self.parent.gudrunFile.purged = False
-
-    def updateDataFilesList(self):
-        """
-        Fills the data files list.
-        """
-        self.widget.dataFilesList.clear()
-        self.widget.dataFilesList.addItems(
-            [df for df in self.normalisation.dataFiles]
-        )
-
-    def handleBgDataFilesAltered(self, item):
-        """
-        Slot for handling an item in the background data files
-        list being entered.
-        Called when an itemEntered signal is emitted,
-        from the backgroundDataFilesList.
-        Alters the normalisation's data files as such.
-        Parameters
-        ----------
-        item : QListWidgetItem
-            The item entered.
-        """
-        index = item.row()
-        value = item.text()
-        if not value:
-            self.normalisation.dataFilesBg.dataFiles.remove(index)
-        else:
-            self.normalisation.dataFilesBg.dataFiles[index] = value
-        self.updateBgDataFilesList()
-        if not self.widgetsRefreshing:
-            self.parent.setModified()
-            self.parent.gudrunFile.purged = False
-
-    def handleBgDataFileInserted(self, item):
-        """
-        Slot for handling an item in the background data files
-        list being inserted.
-        Called when an itemEntered signal is emitted,
-        from the backgroundDataFilesList.
-        Alters the normalisation's data files as such.
-        Parameters
-        ----------
-        item : QListWidgetItem
-            The item entered.
-        """
-        value = item.text()
-        self.normalisation.dataFilesBg.dataFiles.append(value)
-        if not self.widgetsRefreshing:
-            self.parent.setModified()
-            self.parent.gudrunFile.purged = False
-
-    def updateBgDataFilesList(self):
-        self.widget.backgroundDataFilesList.clear()
-        self.widget.backgroundDataFilesList.addItems(
-            [df for df in self.normalisation.dataFilesBg.dataFiles]
-        )
+            self.normalisation.dataFilesBg.dataFiles = self.widget.backgroundDataFilesList.model().stringList()
 
     def addFiles(self, target, title, regex):
         """
@@ -735,7 +660,7 @@ class NormalisationSlots():
         )
         for file in files:
             if file:
-                target.addItem(file.split(os.path.sep)[-1])
+                target.insertRow(file.split(os.path.sep)[-1])
 
     def addDataFiles(self, target, title, regex):
         """
@@ -752,7 +677,6 @@ class NormalisationSlots():
             Regex-like expression to use for specifying file types.
         """
         self.addFiles(target, title, regex)
-        self.handleDataFileInserted(target.item(target.count() - 1))
         if not self.widgetsRefreshing:
             self.parent.setModified()
 
@@ -771,27 +695,11 @@ class NormalisationSlots():
             Regex-like expression to use for specifying file types.
         """
         self.addFiles(target, title, regex)
-        self.handleBgDataFileInserted(target.item(target.count() - 1))
         if not self.widgetsRefreshing:
             self.parent.setModified()
 
-    def removeFile(self, target, dataFiles):
-        """
-        Slot for removing files from the data files list.
-        Called when a clicked signal is emitted,
-        from the removeDataFileButton.
-        """
-        if target.currentIndex().isValid():
-            remove = target.takeItem(target.currentRow()).text()
-            dataFiles.dataFiles.remove(remove)
-            if not self.widgetsRefreshing:
-                self.parent.setModified()
-
-    def removeDataFile(self, target, dataFiles):
-        self.removeFile(target, dataFiles)
-
-    def removeBgDataFile(self, target, dataFiles):
-        self.removeFile(target, dataFiles)
+    def removeDataFile(self, target):
+        target.removeItem()
 
     def updateCompositionTable(self):
         """

--- a/gudpy/gui/widgets/slots/sample_background_slots.py
+++ b/gudpy/gui/widgets/slots/sample_background_slots.py
@@ -49,6 +49,10 @@ class SampleBackgroundSlots():
             )
         )
 
+        self.widget.duplicateSampleBackgroundDataFileButton.clicked.connect(
+            self.widget.sampleBackgroundDataFilesList.duplicate
+        )
+
     def handleDataFilesAltered(self):
         if not self.widgetsRefreshing:
             self.parent.setModified()

--- a/gudpy/gui/widgets/slots/sample_background_slots.py
+++ b/gudpy/gui/widgets/slots/sample_background_slots.py
@@ -20,10 +20,16 @@ class SampleBackgroundSlots():
         )
 
         # Populate data files list.
-        self.widget.sampleBackgroundDataFilesList.makeModel(self.sampleBackground.dataFiles.dataFiles)
+        self.widget.sampleBackgroundDataFilesList.makeModel(
+            self.sampleBackground.dataFiles.dataFiles
+        )
 
-        self.widget.sampleBackgroundDataFilesList.model().dataChanged.connect(self.handleDataFilesAltered)
-        self.widget.sampleBackgroundDataFilesList.model().rowsRemoved.connect(self.handleDataFilesAltered)
+        self.widget.sampleBackgroundDataFilesList.model().dataChanged.connect(
+            self.handleDataFilesAltered
+        )
+        self.widget.sampleBackgroundDataFilesList.model().rowsRemoved.connect(
+            self.handleDataFilesAltered
+        )
 
         # Release the lock
         self.widgetsRefreshing = False
@@ -57,7 +63,9 @@ class SampleBackgroundSlots():
         if not self.widgetsRefreshing:
             self.parent.setModified()
             self.parent.gudrunFile.purged = False
-            self.sampleBackground.dataFiles.dataFiles = self.widget.sampleBackgroundDataFilesList.model().stringList()
+            self.sampleBackground.dataFiles.dataFiles = (
+                self.widget.sampleBackgroundDataFilesList.model().stringList()
+            )
 
     def addFiles(self, target, title, regex):
         files, _ = QFileDialog.getOpenFileNames(

--- a/gudpy/gui/widgets/slots/sample_slots.py
+++ b/gudpy/gui/widgets/slots/sample_slots.py
@@ -194,6 +194,10 @@ class SampleSlots():
             )
         )
 
+        self.widget.duplicateSampleDataFileButton.clicked.connect(
+            self.widget.sampleDataFilesList.duplicate
+        )
+
         # Setup slots for run controls.
         self.widget.sampleForceCorrectionsCheckBox.stateChanged.connect(
             self.handleForceCorrectionsSwitched

--- a/gudpy/gui/widgets/slots/sample_slots.py
+++ b/gudpy/gui/widgets/slots/sample_slots.py
@@ -26,7 +26,10 @@ class SampleSlots():
         self.widget.samplePeriodNoSpinBox.setValue(self.sample.periodNumber)
 
         # Populate the data files list.
-        self.updatesampleDataFilesList()
+        self.widget.sampleDataFilesList.makeModel(self.sample.dataFiles.dataFiles)
+
+        self.widget.sampleDataFilesList.model().dataChanged.connect(self.handleDataFilesAltered)
+        self.widget.sampleDataFilesList.model().rowsRemoved.connect(self.handleDataFilesAltered)
 
         # Populate the run controls.
         self.widget.sampleForceCorrectionsCheckBox.setChecked(
@@ -177,12 +180,6 @@ class SampleSlots():
         )
 
         # Setup slots for data files.
-        self.widget.sampleDataFilesList.itemChanged.connect(
-            self.handleDataFilesAltered
-        )
-        self.widget.sampleDataFilesList.itemEntered.connect(
-            self.handleDataFileInserted
-        )
         self.widget.addSampleDataFileButton.clicked.connect(
             lambda: self.addFiles(
                 self.widget.sampleDataFilesList,
@@ -193,7 +190,7 @@ class SampleSlots():
         )
         self.widget.removeSampleDataFileButton.clicked.connect(
             lambda: self.removeFile(
-                self.widget.sampleDataFilesList, self.sample.dataFiles
+                self.widget.sampleDataFilesList
             )
         )
 
@@ -855,53 +852,18 @@ class SampleSlots():
         if not self.widgetsRefreshing:
             self.parent.setModified()
 
-    def handleDataFilesAltered(self, item):
+    def handleDataFilesAltered(self):
         """
         Slot for handling an item in the data files list being changed.
         Called when an itemChanged signal is emitted,
         from the sampleDataFilesList.
         Alters the sample's data files as such.
-        Parameters
-        ----------
-        item : QListWidgetItem
-            The item altered.
         """
-        index = item.row()
-        value = item.text()
-        if not value:
-            self.sample.dataFiles.dataFiles.remove(index)
-        else:
-            self.sample.dataFiles[index] = value
-        self.updatesampleDataFilesList()
         if not self.widgetsRefreshing:
             self.parent.setModified()
             self.parent.gudrunFile.purged = False
+            self.sample.dataFiles.dataFiles = self.widget.sampleDataFilesList.model().stringList()
 
-    def handleDataFileInserted(self, item):
-        """
-        Slot for handling an item in the data files list being entered.
-        Called when an itemEntered signal is emitted,
-        from the sampleDataFilesList.
-        Alters the sample's data files as such.
-        Parameters
-        ----------
-        item : QListWidgetItem
-            The item entered.
-        """
-        value = item.text()
-        self.sample.dataFiles.dataFiles.append(value)
-        if not self.widgetsRefreshing:
-            self.parent.setModified()
-            self.parent.gudrunFile.purged = False
-
-    def updatesampleDataFilesList(self):
-        """
-        Fills the data files list.
-        """
-        self.widget.sampleDataFilesList.clear()
-        self.widget.sampleDataFilesList.addItems(
-            [df for df in self.sample.dataFiles]
-        )
 
     def addFiles(self, target, title, regex):
         """
@@ -923,12 +885,9 @@ class SampleSlots():
         )
         for file in files:
             if file:
-                target.addItem(file.split(os.path.sep)[-1])
-                self.handleDataFileInserted(target.item(target.count() - 1))
-        if not self.widgetsRefreshing:
-            self.parent.setModified()
+                target.insertRow(file.split(os.path.sep)[-1])
 
-    def removeFile(self, target, dataFiles):
+    def removeFile(self, target):
         """
         Slot for removing files from the data files list.
         Called when a clicked signal is emitted,
@@ -937,15 +896,8 @@ class SampleSlots():
         ----------
         target : QListWidget
             Target widget to add to.
-        dataFiles : list
-            dataFiles attribute belonging to DataFiles object.
         """
-        if target.currentIndex().isValid():
-            remove = target.takeItem(target.currentRow()).text()
-            dataFiles.dataFiles.remove(remove)
-            if not self.widgetsRefreshing:
-                self.parent.setModified()
-                self.parent.gudrunFile.purged = False
+        target.removeItem()
 
     def updateCompositionTable(self):
         """

--- a/gudpy/gui/widgets/slots/sample_slots.py
+++ b/gudpy/gui/widgets/slots/sample_slots.py
@@ -26,10 +26,16 @@ class SampleSlots():
         self.widget.samplePeriodNoSpinBox.setValue(self.sample.periodNumber)
 
         # Populate the data files list.
-        self.widget.sampleDataFilesList.makeModel(self.sample.dataFiles.dataFiles)
+        self.widget.sampleDataFilesList.makeModel(
+            self.sample.dataFiles.dataFiles
+        )
 
-        self.widget.sampleDataFilesList.model().dataChanged.connect(self.handleDataFilesAltered)
-        self.widget.sampleDataFilesList.model().rowsRemoved.connect(self.handleDataFilesAltered)
+        self.widget.sampleDataFilesList.model().dataChanged.connect(
+            self.handleDataFilesAltered
+        )
+        self.widget.sampleDataFilesList.model().rowsRemoved.connect(
+            self.handleDataFilesAltered
+        )
 
         # Populate the run controls.
         self.widget.sampleForceCorrectionsCheckBox.setChecked(
@@ -866,8 +872,9 @@ class SampleSlots():
         if not self.widgetsRefreshing:
             self.parent.setModified()
             self.parent.gudrunFile.purged = False
-            self.sample.dataFiles.dataFiles = self.widget.sampleDataFilesList.model().stringList()
-
+            self.sample.dataFiles.dataFiles = (
+                self.widget.sampleDataFilesList.model().stringList()
+            )
 
     def addFiles(self, target, title, regex):
         """

--- a/gudpy/gui/widgets/tables/data_file_list.py
+++ b/gudpy/gui/widgets/tables/data_file_list.py
@@ -28,10 +28,15 @@ class DataFilesList(QListView):
             self.model().index(self.model().rowCount(QModelIndex()) - 1),
             item
         )
+        self.setCurrentIndex(self.model().index(self.model().rowCount(QModelIndex())-1, 0))
 
+    def duplicate(self):
+        if self.currentIndex().isValid():
+            self.insertRow(self.model().data(self.currentIndex()))
 
     def removeItem(self):
         """
         Removes rows from the model.
         """
-        self.model().removeRow(self.currentIndex().row())
+        if self.currentIndex().isValid():
+            self.model().removeRow(self.currentIndex().row())

--- a/gudpy/gui/widgets/tables/data_file_list.py
+++ b/gudpy/gui/widgets/tables/data_file_list.py
@@ -1,0 +1,37 @@
+from PySide6.QtCore import Qt, QModelIndex, QAbstractItemModel, QStringListModel
+from PySide6.QtWidgets import QTableView, QDoubleSpinBox, QListView
+import os
+from gui.widgets.tables.gudpy_tables import GudPyTableModel, GudPyDelegate
+
+class DataFilesList(QListView):
+
+    def __init__(self, parent):
+        self.parent = parent
+        super(DataFilesList, self).__init__(parent=parent)
+
+    def makeModel(self, data):
+        """
+        Makes the model and the delegate based on the data.
+        Parameters
+        ----------
+        data : list
+            Data for model to use.
+        """
+        self.setModel(QStringListModel(data, self.parent))
+
+    def insertRow(self, item):
+        """
+        Inserts a row into the model.
+        """
+        self.model().insertRows(self.model().rowCount(QModelIndex()), 1)
+        self.model().setData(
+            self.model().index(self.model().rowCount(QModelIndex()) - 1),
+            item
+        )
+
+
+    def removeItem(self):
+        """
+        Removes rows from the model.
+        """
+        self.model().removeRow(self.currentIndex().row())

--- a/gudpy/gui/widgets/tables/data_file_list.py
+++ b/gudpy/gui/widgets/tables/data_file_list.py
@@ -1,7 +1,6 @@
-from PySide6.QtCore import Qt, QModelIndex, QAbstractItemModel, QStringListModel
-from PySide6.QtWidgets import QTableView, QDoubleSpinBox, QListView
-import os
-from gui.widgets.tables.gudpy_tables import GudPyTableModel, GudPyDelegate
+from PySide6.QtCore import QModelIndex, QStringListModel
+from PySide6.QtWidgets import QListView
+
 
 class DataFilesList(QListView):
 
@@ -28,7 +27,9 @@ class DataFilesList(QListView):
             self.model().index(self.model().rowCount(QModelIndex()) - 1),
             item
         )
-        self.setCurrentIndex(self.model().index(self.model().rowCount(QModelIndex())-1, 0))
+        self.setCurrentIndex(
+            self.model().index(self.model().rowCount(QModelIndex())-1, 0)
+        )
 
     def duplicate(self):
         if self.currentIndex().isValid():

--- a/gudpy/gui/widgets/ui_files/mainWindow.ui
+++ b/gudpy/gui/widgets/ui_files/mainWindow.ui
@@ -52,7 +52,7 @@
              </sizepolicy>
             </property>
             <property name="currentIndex">
-             <number>4</number>
+             <number>5</number>
             </property>
             <widget class="QWidget" name="instrumentPage">
              <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -4493,7 +4493,7 @@
                        </property>
                        <layout class="QHBoxLayout" name="horizontalLayout_53">
                         <item>
-                         <widget class="QListWidget" name="sampleDataFilesList"/>
+                         <widget class="DataFilesList" name="sampleDataFilesList"/>
                         </item>
                         <item>
                          <layout class="QVBoxLayout" name="verticalLayout_25">

--- a/gudpy/gui/widgets/ui_files/mainWindow.ui
+++ b/gudpy/gui/widgets/ui_files/mainWindow.ui
@@ -52,7 +52,7 @@
              </sizepolicy>
             </property>
             <property name="currentIndex">
-             <number>3</number>
+             <number>4</number>
             </property>
             <widget class="QWidget" name="instrumentPage">
              <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -4339,7 +4339,7 @@
                  <item>
                   <layout class="QHBoxLayout" name="horizontalLayout_49">
                    <item>
-                    <widget class="QListWidget" name="sampleBackgroundDataFilesList">
+                    <widget class="DataFilesList" name="sampleBackgroundDataFilesList">
                      <property name="sizePolicy">
                       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                        <horstretch>0</horstretch>

--- a/gudpy/gui/widgets/ui_files/mainWindow.ui
+++ b/gudpy/gui/widgets/ui_files/mainWindow.ui
@@ -52,7 +52,7 @@
              </sizepolicy>
             </property>
             <property name="currentIndex">
-             <number>0</number>
+             <number>3</number>
             </property>
             <widget class="QWidget" name="instrumentPage">
              <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -3268,7 +3268,7 @@
                    <item>
                     <layout class="QVBoxLayout" name="verticalLayout_17">
                      <item>
-                      <widget class="QListWidget" name="dataFilesList">
+                      <widget class="DataFilesList" name="dataFilesList">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
                          <horstretch>0</horstretch>
@@ -3409,7 +3409,7 @@
                    <item>
                     <layout class="QVBoxLayout" name="verticalLayout_19">
                      <item>
-                      <widget class="QListWidget" name="backgroundDataFilesList">
+                      <widget class="DataFilesList" name="backgroundDataFilesList">
                        <property name="sizePolicy">
                         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
                          <horstretch>0</horstretch>
@@ -5928,6 +5928,7 @@
                         <widget class="QLabel" name="expectedDcsLabel">
                          <property name="font">
                           <font>
+                           <weight>75</weight>
                            <bold>true</bold>
                           </font>
                          </property>
@@ -5946,6 +5947,7 @@
                         <widget class="QLabel" name="dcsLabel">
                          <property name="font">
                           <font>
+                           <weight>75</weight>
                            <bold>true</bold>
                           </font>
                          </property>
@@ -5964,6 +5966,7 @@
                         <widget class="QLabel" name="resultLabel">
                          <property name="font">
                           <font>
+                           <weight>75</weight>
                            <bold>true</bold>
                           </font>
                          </property>
@@ -5984,6 +5987,7 @@
                       <widget class="QLabel" name="suggestedTweakFactorLabel">
                        <property name="font">
                         <font>
+                         <weight>75</weight>
                          <bold>true</bold>
                         </font>
                        </property>
@@ -7052,6 +7056,7 @@
                         <widget class="QLabel" name="containerExpectedDcsLabel">
                          <property name="font">
                           <font>
+                           <weight>75</weight>
                            <bold>true</bold>
                           </font>
                          </property>
@@ -7070,6 +7075,7 @@
                         <widget class="QLabel" name="containerDcsLabel">
                          <property name="font">
                           <font>
+                           <weight>75</weight>
                            <bold>true</bold>
                           </font>
                          </property>
@@ -7088,6 +7094,7 @@
                         <widget class="QLabel" name="containerResultLabel">
                          <property name="font">
                           <font>
+                           <weight>75</weight>
                            <bold>true</bold>
                           </font>
                          </property>
@@ -7108,6 +7115,7 @@
                       <widget class="QLabel" name="containerSuggestedTweakFactorLabel">
                        <property name="font">
                         <font>
+                         <weight>75</weight>
                          <bold>true</bold>
                         </font>
                        </property>
@@ -7578,6 +7586,11 @@
    <class>OutputTreeView</class>
    <extends>QTreeView</extends>
    <header>src.gui.widgets.output_tree</header>
+  </customwidget>
+  <customwidget>
+   <class>DataFilesList</class>
+   <extends>QListView</extends>
+   <header>src.gui.widgets.tables.data_file_list</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/gudpy/gui/widgets/ui_files/mainWindow.ui
+++ b/gudpy/gui/widgets/ui_files/mainWindow.ui
@@ -52,7 +52,7 @@
              </sizepolicy>
             </property>
             <property name="currentIndex">
-             <number>5</number>
+             <number>6</number>
             </property>
             <widget class="QWidget" name="instrumentPage">
              <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -6079,7 +6079,7 @@
                          <item>
                           <layout class="QVBoxLayout" name="verticalLayout_44">
                            <item>
-                            <widget class="QListWidget" name="containerDataFilesList">
+                            <widget class="DataFilesList" name="containerDataFilesList">
                              <property name="sizePolicy">
                               <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
                                <horstretch>0</horstretch>

--- a/gudpy/gui/widgets/ui_files/mainWindow.ui
+++ b/gudpy/gui/widgets/ui_files/mainWindow.ui
@@ -3365,6 +3365,17 @@
                       </widget>
                      </item>
                      <item>
+                      <widget class="QToolButton" name="duplicateDataFileButton">
+                       <property name="text">
+                        <string>...</string>
+                       </property>
+                       <property name="icon">
+                        <iconset resource="../resources/resources.qrc">
+                         <normaloff>:/icons/duplicate.png</normaloff>:/icons/duplicate.png</iconset>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
                       <spacer name="verticalSpacer_7">
                        <property name="orientation">
                         <enum>Qt::Vertical</enum>
@@ -3502,6 +3513,17 @@
                        <property name="icon">
                         <iconset resource="../resources/resources.qrc">
                          <normaloff>:/icons/minus.png</normaloff>:/icons/minus.png</iconset>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QToolButton" name="duplicateBackgroundDataFileButton">
+                       <property name="text">
+                        <string>...</string>
+                       </property>
+                       <property name="icon">
+                        <iconset resource="../resources/resources.qrc">
+                         <normaloff>:/icons/duplicate.png</normaloff>:/icons/duplicate.png</iconset>
                        </property>
                       </widget>
                      </item>
@@ -4335,7 +4357,7 @@
                 <property name="title">
                  <string>Data Files</string>
                 </property>
-                <layout class="QVBoxLayout" name="verticalLayout_22">
+                <layout class="QVBoxLayout" name="verticalLayout_23">
                  <item>
                   <layout class="QHBoxLayout" name="horizontalLayout_49">
                    <item>
@@ -4349,7 +4371,7 @@
                     </widget>
                    </item>
                    <item>
-                    <layout class="QVBoxLayout" name="verticalLayout_23">
+                    <layout class="QVBoxLayout" name="verticalLayout_22">
                      <item>
                       <widget class="QToolButton" name="addSampleBackgroundDataFileButton">
                        <property name="sizePolicy">
@@ -4381,6 +4403,17 @@
                        <property name="icon">
                         <iconset resource="../resources/resources.qrc">
                          <normaloff>:/icons/minus.png</normaloff>:/icons/minus.png</iconset>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QToolButton" name="duplicateSampleBackgroundDataFileButton">
+                       <property name="text">
+                        <string>...</string>
+                       </property>
+                       <property name="icon">
+                        <iconset resource="../resources/resources.qrc">
+                         <normaloff>:/icons/duplicate.png</normaloff>:/icons/duplicate.png</iconset>
                        </property>
                       </widget>
                      </item>
@@ -4528,6 +4561,17 @@
                             <property name="icon">
                              <iconset resource="../resources/resources.qrc">
                               <normaloff>:/icons/minus.png</normaloff>:/icons/minus.png</iconset>
+                            </property>
+                           </widget>
+                          </item>
+                          <item>
+                           <widget class="QToolButton" name="duplicateSampleDataFileButton">
+                            <property name="text">
+                             <string>...</string>
+                            </property>
+                            <property name="icon">
+                             <iconset resource="../resources/resources.qrc">
+                              <normaloff>:/icons/duplicate.png</normaloff>:/icons/duplicate.png</iconset>
                             </property>
                            </widget>
                           </item>
@@ -6172,6 +6216,17 @@
                              <property name="icon">
                               <iconset resource="../resources/resources.qrc">
                                <normaloff>:/icons/minus.png</normaloff>:/icons/minus.png</iconset>
+                             </property>
+                            </widget>
+                           </item>
+                           <item>
+                            <widget class="QToolButton" name="duplicateContainerDataFileButton">
+                             <property name="text">
+                              <string>...</string>
+                             </property>
+                             <property name="icon">
+                              <iconset resource="../resources/resources.qrc">
+                               <normaloff>:/icons/duplicate.png</normaloff>:/icons/duplicate.png</iconset>
                              </property>
                             </widget>
                            </item>


### PR DESCRIPTION
This PR implements a explicit `QListView` for data files, which maintains a `QStringListModel`. This allows the list items to be mutable. Furthermore, a "duplicate" functionality has been implemented for data files.

Closes #356.