### PR TITLE
Strict Composition Table

### DIFF
--- a/gudpy/core/isotopes.py
+++ b/gudpy/core/isotopes.py
@@ -424,6 +424,11 @@ class Sears91():
             if self.element(isotope) == element
         ]
 
+    def findIsotope(self, element, mass):
+        for isotope in self.isotopes(element):
+            if self.mass(isotope) == mass:
+                return isotope
+
     def isIsotope(self, element, mass):
         isotopes = self.isotopes(element)
         for isotope in isotopes:

--- a/gudpy/gui/widgets/tables/components_table.py
+++ b/gudpy/gui/widgets/tables/components_table.py
@@ -8,7 +8,6 @@ from core.mass_data import massData
 from core.composition import Component
 from core.element import Element
 from core.isotopes import Sears91
-from gui.widgets.tables.composition_table import CompositionDelegate
 from gui.widgets.tables.composition_delegate import CompositionDelegate
 
 

--- a/gudpy/gui/widgets/tables/components_table.py
+++ b/gudpy/gui/widgets/tables/components_table.py
@@ -7,6 +7,7 @@ from PySide6.QtWidgets import QListView
 from core.mass_data import massData
 from core.composition import Component
 from core.element import Element
+from core.isotopes import Sears91
 from gui.widgets.tables.composition_table import CompositionDelegate
 
 
@@ -218,7 +219,12 @@ class ComponentsModel(QAbstractItemModel):
                 if index.column() == 0:
                     return obj.atomicSymbol
                 elif index.column() == 1:
-                    return obj.massNo
+                    sears91 = Sears91()
+                    isotope = sears91.findIsotope(
+                        obj.atomicSymbol,
+                        obj.massNo
+                    )
+                    return sears91.isotope(isotope)
                 elif index.column() == 2:
                     return obj.abundance
         else:
@@ -351,7 +357,7 @@ class ComponentsModel(QAbstractItemModel):
             column header | empty QVariant.
         """
         if orientation == Qt.Horizontal and role == Qt.DisplayRole:
-            return ["Atomic Symbol", "Mass No.", "Abundance"][section]
+            return ["Atomic Symbol", "Isotope", "Abundance"][section]
 
 
 class ComponentsList(QListView):

--- a/gudpy/gui/widgets/tables/components_table.py
+++ b/gudpy/gui/widgets/tables/components_table.py
@@ -9,6 +9,7 @@ from core.composition import Component
 from core.element import Element
 from core.isotopes import Sears91
 from gui.widgets.tables.composition_table import CompositionDelegate
+from gui.widgets.tables.composition_delegate import CompositionDelegate
 
 
 class ComponentsModel(QAbstractItemModel):

--- a/gudpy/gui/widgets/tables/composition_delegate.py
+++ b/gudpy/gui/widgets/tables/composition_delegate.py
@@ -1,0 +1,95 @@
+from PySide6.QtWidgets import QLineEdit, QComboBox
+from PySide6.QtCore import Qt
+from core.isotopes import Sears91
+from gui.widgets.core.exponential_spinbox import ExponentialSpinBox
+from gui.widgets.tables.gudpy_tables import GudPyDelegate
+
+
+class CompositionDelegate(GudPyDelegate):
+    """
+    Class to represent a CompositionDelegate. Inherits GudPyDelegate.
+
+    ...
+
+    Methods
+    -------
+    createEditor(parent, option, index)
+        Creates an editor.
+    setEditorData(editor, index)
+        Sets data at a specific index inside the editor.
+    setModelData(editor, model, index)
+        Sets data at a specific index inside the model.
+    """
+
+    def createEditor(self, parent, option, index):
+        """
+        Creates an editor, and returns it.
+        Parameters
+        ----------
+        parent : QWidget
+            Parent widget.
+        option : QStyleOptionViewItem
+            Option.
+        index : QModelIndex
+            Index in to create editor at.
+        Returns
+        -------
+        QLineEdit | QSpinBox | QDoubleSpinBox
+            The created editor.
+        """
+        col = index.column()
+        if col == 0:
+            editor = QLineEdit(parent)
+        elif col == 1:
+            editor = QComboBox(parent)
+            sears91 = Sears91()
+            element = index.model().data(index.model().index(index.row(), 0, index.parent()), Qt.EditRole)
+            isotope = index.model().data(index.model().index(index.row(), 1, index.parent()), Qt.EditRole)
+            for isotope_ in sears91.isotopes(element):
+                editor.addItem(sears91.isotope(isotope_), sears91.mass(isotope_))
+            editor.setCurrentText(isotope)
+        else:
+            editor = ExponentialSpinBox(parent)
+        return editor
+
+    def setEditorData(self, editor, index):
+        """
+        Sets data at a specific index inside the editor.
+        Parameters
+        ----------
+        editor : QWidget
+            The editor widet.
+        index : QModelIndex
+            Index in the model to set data at.
+        """
+        value = index.model().data(index, Qt.EditRole)
+        if index.column() == 0:
+            sears91 = Sears91()
+            if sears91.isIsotope(value, 0):
+                editor.setText(value)
+        elif index.column() == 2:
+            editor.setValue(value)
+
+    def setModelData(self, editor, model, index):
+        """
+        Sets data at a specific index inside the model.
+        Parameters
+        ----------
+        editor : QWidget
+            The editor widet.
+        model : GudPyTableModel
+            Model to set data inside.
+        index : QModelIndex
+            Index in the model to set data at.
+        """
+        if index.column() == 0:
+            value = editor.text()
+        elif index.column() == 1:
+            value = editor.currentData()
+        elif index.column() == 2:
+            try:
+                editor.interpretText()
+                value = editor.value()
+            except Exception:
+                value = 0
+        model.setData(index, value, Qt.EditRole)

--- a/gudpy/gui/widgets/tables/composition_delegate.py
+++ b/gudpy/gui/widgets/tables/composition_delegate.py
@@ -43,10 +43,19 @@ class CompositionDelegate(GudPyDelegate):
         elif col == 1:
             editor = QComboBox(parent)
             sears91 = Sears91()
-            element = index.model().data(index.model().index(index.row(), 0, index.parent()), Qt.EditRole)
-            isotope = index.model().data(index.model().index(index.row(), 1, index.parent()), Qt.EditRole)
+            element = index.model().data(
+                index.model().index(index.row(), 0, index.parent()),
+                Qt.EditRole
+            )
+            isotope = index.model().data(
+                index.model().index(index.row(), 1, index.parent()),
+                Qt.EditRole
+            )
             for isotope_ in sears91.isotopes(element):
-                editor.addItem(sears91.isotope(isotope_), sears91.mass(isotope_))
+                editor.addItem(
+                    sears91.isotope(isotope_),
+                    sears91.mass(isotope_)
+                )
             editor.setCurrentText(isotope)
         else:
             editor = ExponentialSpinBox(parent)

--- a/gudpy/gui/widgets/tables/composition_table.py
+++ b/gudpy/gui/widgets/tables/composition_table.py
@@ -84,11 +84,22 @@ class CompositionModel(GudPyTableModel):
                     return True
                 elif value not in massData.keys():
                     return False
-                if not sears91.isIsotope(value, self._data[row].__dict__[self.attrs[1]]):
+                if not sears91.isIsotope(
+                    value, self._data[row].__dict__[self.attrs[1]]
+                ):
                     self._data[row].__dict__[self.attrs[1]] = 0
-                    self.dataChanged.emit(self.index(row, 1, QModelIndex()), self.index(row, 1, QModelIndex()))
+                    self.dataChanged.emit(
+                        self.index(row, 1, QModelIndex()),
+                        self.index(row, 1, QModelIndex())
+                    )
             if col == 1:
-                if self._data[row].__dict__[self.attrs[0]] and not sears91.isIsotope(self._data[row].__dict__[self.attrs[0]], value):
+                if (
+                    self._data[row].__dict__[self.attrs[0]]
+                    and not sears91.isIsotope(
+                        self._data[row].__dict__[self.attrs[0]],
+                        value
+                    )
+                ):
                     return False
             self._data[row].__dict__[self.attrs[col]] = value
             self.dataChanged.emit(index, index)

--- a/gudpy/gui/widgets/tables/composition_table.py
+++ b/gudpy/gui/widgets/tables/composition_table.py
@@ -81,6 +81,7 @@ class CompositionModel(GudPyTableModel):
                 if value == "D":
                     self._data[row].atomicSymbol = "H"
                     self._data[row].massNo = 2
+                    self.dataChanged.emit(index, index)
                     return True
                 elif value not in massData.keys():
                     return False

--- a/gudpy/gui/widgets/tables/composition_table.py
+++ b/gudpy/gui/widgets/tables/composition_table.py
@@ -100,7 +100,7 @@ class CompositionModel(GudPyTableModel):
                         self._data[row].__dict__[self.attrs[0]],
                         value
                     )
-                ): 
+                ):
                     return False
             self._data[row].__dict__[self.attrs[col]] = value
             self.dataChanged.emit(index, index)
@@ -152,6 +152,7 @@ class CompositionModel(GudPyTableModel):
                 )
                 return sears91.isotope(isotope)
             return self._data[row].__dict__[self.attrs[col]]
+
 
 class CompositionTable(QTableView):
     """

--- a/gudpy/gui/widgets/tables/composition_table.py
+++ b/gudpy/gui/widgets/tables/composition_table.py
@@ -1,15 +1,15 @@
 from PySide6.QtCore import QModelIndex, Qt
 from PySide6.QtGui import QAction, QCursor
 from PySide6.QtWidgets import (
-    QLineEdit, QMainWindow, QMenu, QComboBox, QTableView
+    QMainWindow, QMenu, QTableView
 )
 from PySide6.QtCore import Signal
 
 from core import config
 from core.mass_data import massData
 from core.isotopes import Sears91
-from gui.widgets.tables.gudpy_tables import GudPyTableModel, GudPyDelegate
-from gui.widgets.core.exponential_spinbox import ExponentialSpinBox
+from gui.widgets.tables.gudpy_tables import GudPyTableModel
+from gui.widgets.tables.composition_delegate import CompositionDelegate
 from core.element import Element
 from copy import deepcopy
 
@@ -152,97 +152,6 @@ class CompositionModel(GudPyTableModel):
                 )
                 return sears91.isotope(isotope)
             return self._data[row].__dict__[self.attrs[col]]
-
-
-class CompositionDelegate(GudPyDelegate):
-    """
-    Class to represent a CompositionDelegate. Inherits GudPyDelegate.
-
-    ...
-
-    Methods
-    -------
-    createEditor(parent, option, index)
-        Creates an editor.
-    setEditorData(editor, index)
-        Sets data at a specific index inside the editor.
-    setModelData(editor, model, index)
-        Sets data at a specific index inside the model.
-    """
-
-    def createEditor(self, parent, option, index):
-        """
-        Creates an editor, and returns it.
-        Parameters
-        ----------
-        parent : QWidget
-            Parent widget.
-        option : QStyleOptionViewItem
-            Option.
-        index : QModelIndex
-            Index in to create editor at.
-        Returns
-        -------
-        QLineEdit | QSpinBox | QDoubleSpinBox
-            The created editor.
-        """
-        col = index.column()
-        if col == 0:
-            editor = QLineEdit(parent)
-        elif col == 1:
-            editor = QComboBox(parent)
-            sears91 = Sears91()
-            element = index.model().data(index.model().index(index.row(), 0), Qt.EditRole)
-            isotope = index.model().data(index.model().index(index.row(), 1), Qt.EditRole)
-            for isotope_ in sears91.isotopes(element):
-                editor.addItem(sears91.isotope(isotope_), sears91.mass(isotope_))
-            editor.setCurrentText(isotope)
-
-        else:
-            editor = ExponentialSpinBox(parent)
-        return editor
-
-    def setEditorData(self, editor, index):
-        """
-        Sets data at a specific index inside the editor.
-        Parameters
-        ----------
-        editor : QWidget
-            The editor widet.
-        index : QModelIndex
-            Index in the model to set data at.
-        """
-        value = index.model().data(index, Qt.EditRole)
-        if index.column() == 0:
-            sears91 = Sears91()
-            if sears91.isIsotope(value, 0):
-                editor.setText(value)
-        elif index.column() == 2:
-            editor.setValue(value)
-
-    def setModelData(self, editor, model, index):
-        """
-        Sets data at a specific index inside the model.
-        Parameters
-        ----------
-        editor : QWidget
-            The editor widet.
-        model : GudPyTableModel
-            Model to set data inside.
-        index : QModelIndex
-            Index in the model to set data at.
-        """
-        if index.column() == 0:
-            value = editor.text()
-        elif index.column() == 1:
-            value = editor.currentData()
-        elif index.column() == 2:
-            try:
-                editor.interpretText()
-                value = editor.value()
-            except Exception:
-                value = 0
-        model.setData(index, value, Qt.EditRole)
 
 class CompositionTable(QTableView):
     """

--- a/gudpy/test/test_models.py
+++ b/gudpy/test/test_models.py
@@ -178,16 +178,6 @@ class TestModels(TestCase):
         )
 
         model.insertRow()
-        self.assertEqual(
-            model.data(model.index(1, 0, QModelIndex()), Qt.EditRole), ""
-        )
-        self.assertEqual(
-            model.data(model.index(1, 1, QModelIndex()), Qt.EditRole), 0
-        )
-        self.assertEqual(
-            model.data(model.index(1, 2, QModelIndex()), Qt.EditRole), 0.0
-        )
-
         model.setData(model.index(1, 0, QModelIndex()), "Ti", Qt.EditRole)
         model.setData(model.index(1, 1, QModelIndex()), 0, Qt.EditRole)
         model.setData(model.index(1, 2, QModelIndex()), 7.16, Qt.EditRole)

--- a/gudpy/test/test_models.py
+++ b/gudpy/test/test_models.py
@@ -161,7 +161,7 @@ class TestModels(TestCase):
         )
         self.assertEqual(
             model.data(model.index(0, 1, QModelIndex()), Qt.EditRole),
-            self.sears91.mass(self.sears91.isotope("V"))
+            self.sears91.mass(self.sears91.findIsotope("V", 0))
         )
         self.assertEqual(
             model.data(model.index(0, 2, QModelIndex()), Qt.EditRole), 1.0

--- a/gudpy/test/test_models.py
+++ b/gudpy/test/test_models.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 
 from PySide6.QtCore import QModelIndex, Qt
 from gudpy.core.element import Element
+from gudpy.core.isotopes import Sears91
 
 from gui.widgets.tables.gudpy_tables import GudPyTableModel
 from gui.widgets.tables.beam_profile_table import BeamProfileModel
@@ -14,6 +15,11 @@ from gui.widgets.tables.resonance_table import ResonanceModel
 
 
 class TestModels(TestCase):
+
+    def setUp(self):
+        self.sears91 = Sears91()
+        return super().setUp()
+
     def testGudPyTableModel(self):
 
         model = GudPyTableModel([["test"]], ["test"], None)
@@ -154,7 +160,8 @@ class TestModels(TestCase):
             model.data(model.index(0, 0, QModelIndex()), Qt.EditRole), "V"
         )
         self.assertEqual(
-            model.data(model.index(0, 1, QModelIndex()), Qt.EditRole), 0
+            model.data(model.index(0, 1, QModelIndex()), Qt.EditRole),
+            self.sears91.mass(self.sears91.isotope("V"))
         )
         self.assertEqual(
             model.data(model.index(0, 2, QModelIndex()), Qt.EditRole), 1.0
@@ -188,7 +195,8 @@ class TestModels(TestCase):
             model.data(model.index(1, 0, QModelIndex()), Qt.EditRole), "Ti"
         )
         self.assertEqual(
-            model.data(model.index(1, 1, QModelIndex()), Qt.EditRole), 0
+            model.data(model.index(1, 1, QModelIndex()), Qt.EditRole),
+            self.sears91.mass(self.sears91.isotope("Ti"))
         )
         self.assertEqual(
             model.data(model.index(1, 2, QModelIndex()), Qt.EditRole), 7.16

--- a/gudpy/test/test_models.py
+++ b/gudpy/test/test_models.py
@@ -196,7 +196,7 @@ class TestModels(TestCase):
         )
         self.assertEqual(
             model.data(model.index(1, 1, QModelIndex()), Qt.EditRole),
-            self.sears91.mass(self.sears91.isotope("Ti"))
+            self.sears91.mass(self.sears91.findIsotope("Ti", 0))
         )
         self.assertEqual(
             model.data(model.index(1, 2, QModelIndex()), Qt.EditRole), 7.16

--- a/gudpy/test/test_models.py
+++ b/gudpy/test/test_models.py
@@ -161,7 +161,7 @@ class TestModels(TestCase):
         )
         self.assertEqual(
             model.data(model.index(0, 1, QModelIndex()), Qt.EditRole),
-            self.sears91.mass(self.sears91.findIsotope("V", 0))
+            self.sears91.isotope(self.sears91.findIsotope("V", 0))
         )
         self.assertEqual(
             model.data(model.index(0, 2, QModelIndex()), Qt.EditRole), 1.0
@@ -196,7 +196,7 @@ class TestModels(TestCase):
         )
         self.assertEqual(
             model.data(model.index(1, 1, QModelIndex()), Qt.EditRole),
-            self.sears91.mass(self.sears91.findIsotope("Ti", 0))
+            self.sears91.isotope(self.sears91.findIsotope("Ti", 0))
         )
         self.assertEqual(
             model.data(model.index(1, 2, QModelIndex()), Qt.EditRole), 7.16


### PR DESCRIPTION
This PR makes the composition tables throughout the GUI stricter.

- When a mass number is entered, the atomic symbol is used to determine if this is a valid isotope. If it is not, then the mass number is not applied.
- When an atomic symbol is entered, the mass number is used to determine if this is a valid isotope. If it is not, then the mass number is set to zero (natural).

The main purpose for this PR is that when invalid isotopes are entered, it breaks the expected DCS level calculations.

Doesn't really need testing or code review, just looking for conceptual feedback!