### PR TITLE
Cancel Iterations

### DIFF
--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -1224,7 +1224,7 @@ class GudPyMainWindow(QMainWindow):
         self.setControlsEnabled(False)
         iterationDialog = dialog(name, self.gudrunFile, self.mainWidget)
         iterationDialog.widget.exec()
-        if iterationDialog.cancelled or not iterationDialog.iterator:
+        if not iterationDialog.iterator:
             self.setControlsEnabled(True)
         else:
             self.queue = iterationDialog.queue

--- a/gudpy/gui/widgets/dialogs/iterate_density_dialog.py
+++ b/gudpy/gui/widgets/dialogs/iterate_density_dialog.py
@@ -4,11 +4,8 @@ from core.density_iterator import DensityIterator
 
 class DensityIterationDialog(IterationDialog):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.iterator = DensityIterator(self.gudrunFile)
-
     def iterate(self):
+        self.iterator = DensityIterator(self.gudrunFile)
         self.enqueueTasks()
         self.text = "Iterate by Density"
         self.widget.close()

--- a/gudpy/gui/widgets/dialogs/iterate_inelasticity_subtractions_dialog.py
+++ b/gudpy/gui/widgets/dialogs/iterate_inelasticity_subtractions_dialog.py
@@ -6,11 +6,8 @@ from core.wavelength_subtraction_iterator import (
 
 class WavelengthInelasticitySubtractionsIterationDialog(IterationDialog):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.iterator = WavelengthSubtractionIterator(self.gudrunFile)
-
     def iterate(self):
+        self.iterator = WavelengthSubtractionIterator(self.gudrunFile)
         self.numberIterations *= 2
         self.enqueueTasks()
         self.text = "Inelasticity subtractions"

--- a/gudpy/gui/widgets/dialogs/iterate_radius_dialog.py
+++ b/gudpy/gui/widgets/dialogs/iterate_radius_dialog.py
@@ -6,11 +6,6 @@ from core import config
 
 class RadiusIterationDialog(IterationDialog):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.iterator = RadiusIterator(self.gudrunFile)
-        self.iterator.setTargetRadius("inner")
-
     def initComponents(self):
         super().initComponents()
         self.widget.iterateButton.setEnabled(
@@ -18,6 +13,8 @@ class RadiusIterationDialog(IterationDialog):
         )
 
     def iterate(self):
+        self.iterator = RadiusIterator(self.gudrunFile)
+        self.iterator.setTargetRadius("inner")
         self.enqueueTasks()
         self.text = "Iterate by Radius"
         self.widget.close()

--- a/gudpy/gui/widgets/dialogs/iterate_thickness_dialog.py
+++ b/gudpy/gui/widgets/dialogs/iterate_thickness_dialog.py
@@ -6,10 +6,6 @@ from core import config
 
 class ThicknessIterationDialog(IterationDialog):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.iterator = ThicknessIterator(self.gudrunFile)
-
     def initComponents(self):
         super().initComponents()
         self.widget.iterateButton.setEnabled(
@@ -17,6 +13,7 @@ class ThicknessIterationDialog(IterationDialog):
         )
 
     def iterate(self):
+        self.iterator = ThicknessIterator(self.gudrunFile)
         self.enqueueTasks()
         self.text = "Iterate by Thickness"
         self.widget.close()

--- a/gudpy/gui/widgets/dialogs/iterate_tweak_factor_dialog.py
+++ b/gudpy/gui/widgets/dialogs/iterate_tweak_factor_dialog.py
@@ -4,11 +4,8 @@ from core.tweak_factor_iterator import TweakFactorIterator
 
 class TweakFactorIterationDialog(IterationDialog):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.iterator = TweakFactorIterator(self.gudrunFile)
-
     def iterate(self):
+        self.iterator = TweakFactorIterator(self.gudrunFile)
         self.enqueueTasks()
         self.text = "Iterate by Tweak Factor"
         self.widget.close()

--- a/gudpy/gui/widgets/dialogs/iteration_dialog.py
+++ b/gudpy/gui/widgets/dialogs/iteration_dialog.py
@@ -13,7 +13,6 @@ class IterationDialog(QDialog):
         self.gudrunFile = gudrunFile
         self.name = name
         self.numberIterations = 1
-        self.cancelled = False
         self.iterator = None
         self.text = ""
         self.loadUI()


### PR DESCRIPTION
Small PR to fix a major bug with cancelling iteration dialogs freezing the GUI (i.e. controls not being unlocked as they should be).

Closes #363.