### PR TITLE
Nexus Dialog Fix

### DIFF
--- a/ci/singularity/ubuntu20.04.def
+++ b/ci/singularity/ubuntu20.04.def
@@ -6,7 +6,7 @@ From: ubuntu:20.04
     ./requirements.txt requirements.txt
 
 %post
-    DEBIAN_FRONTEND=noninteractive
+    export DEBIAN_FRONTEND=noninteractive
     apt-get update
     apt-get install python3.8 python3-distutils curl build-essential libx11-xcb-dev libglu1-mesa-dev libxkbcommon0 libglx0 libfontconfig libglib2.0-0 libdbus-1-3 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0 libgfortran5 -y && rm -rf /var/lib/apt/lists/*
     curl https://bootstrap.pypa.io/get-pip.py | python3.8
@@ -19,6 +19,7 @@ From: ubuntu:20.04
     cd
     python3.8 -m pip uninstall pip -y
     apt-get remove curl -y
+    unset DEBIAN_FRONTEND
     
 
 %help

--- a/ci/singularity/ubuntu20.04.def
+++ b/ci/singularity/ubuntu20.04.def
@@ -6,6 +6,7 @@ From: ubuntu:20.04
     ./requirements.txt requirements.txt
 
 %post
+    DEBIAN_FRONTEND=noninteractive
     apt-get update
     apt-get install python3.8 python3-distutils curl build-essential libx11-xcb-dev libglu1-mesa-dev libxkbcommon0 libglx0 libfontconfig libglib2.0-0 libdbus-1-3 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0 libgfortran5 -y && rm -rf /var/lib/apt/lists/*
     curl https://bootstrap.pypa.io/get-pip.py | python3.8

--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -536,6 +536,8 @@ class GudPyMainWindow(QMainWindow):
             self.mainWidget.runNexusProcessing.setVisible(
                 True
             )
+        
+        self.mainWidget.runNexusProcessing.triggered.connect(self.nexusProcessing)
 
     def tryLoadAutosaved(self, path):
         dir_ = os.path.dirname(path)

--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -536,8 +536,10 @@ class GudPyMainWindow(QMainWindow):
             self.mainWidget.runNexusProcessing.setVisible(
                 True
             )
-        
-        self.mainWidget.runNexusProcessing.triggered.connect(self.nexusProcessing)
+
+        self.mainWidget.runNexusProcessing.triggered.connect(
+            self.nexusProcessing
+        )
 
     def tryLoadAutosaved(self, path):
         dir_ = os.path.dirname(path)

--- a/gudpy/gui/widgets/slots/instrument_slots.py
+++ b/gudpy/gui/widgets/slots/instrument_slots.py
@@ -516,6 +516,9 @@ class InstrumentSlots():
         self.widget.browseNexusDefinitionButton.setEnabled(
             self.instrument.dataFileType in ["nxs", "NXS"]
         )
+        self.widget.runNexusProcessing.setEnabled(
+            self.instrument.dataFileType in ["nxs", "NXS"]
+        )
         if not self.widgetsRefreshing:
             self.parent.setModified()
 


### PR DESCRIPTION
The "Nexus Processing" button had no slot connected to its "triggered" signal. This has been fixed, and now also gets enabled/disabled with change of data file type.