### PR TITLE
Fix legend marker click events

### DIFF
--- a/gudpy/gui/widgets/charts/chartview.py
+++ b/gudpy/gui/widgets/charts/chartview.py
@@ -131,7 +131,7 @@ class GudPyChartView(QChartView):
                 self.rubberBandOrigin = event.pos()
 
             event.accept()
-            return super().mousePressEvent(event)
+        return super().mousePressEvent(event)
 
     def copyPlot(self):
         pixMap = self.grab()
@@ -163,8 +163,8 @@ class GudPyChartView(QChartView):
                 self.setRubberBand(QChartView.NoRubberBand)
                 event.accept()
                 self.setRubberBand(QChartView.RectangleRubberBand)
-            else:
-                return super(GudPyChartView, self).mouseReleaseEvent(event)
+        return super(GudPyChartView, self).mouseReleaseEvent(event)
+            
 
     def keyPressEvent(self, event):
         """

--- a/gudpy/gui/widgets/charts/chartview.py
+++ b/gudpy/gui/widgets/charts/chartview.py
@@ -164,7 +164,6 @@ class GudPyChartView(QChartView):
                 event.accept()
                 self.setRubberBand(QChartView.RectangleRubberBand)
         return super(GudPyChartView, self).mouseReleaseEvent(event)
-            
 
     def keyPressEvent(self, event):
         """


### PR DESCRIPTION
Series were not being toggled on marker clicks, this PR fixes this by ensuring that mouse click/release events cascade down the widget hierarchy, i.e. from the GudPyChartView to the GudPyChart. Closes #375.