### PR TITLE
Fix NeXuS processing progression.

### DIFF
--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -1392,7 +1392,7 @@ class GudPyMainWindow(QMainWindow):
         self.proc = None
         self.outputSlots.setOutput(
             self.nexusProcessingOutput, "gudrun_dcs",
-            gudrunFile=self.gudrunFile.batch_processing.gudrunFile,
+            gudrunFile=self.gudrunFile.nexus_processing.gudrunFile,
             keyMap=self.keyMap
         )
 


### PR DESCRIPTION
Another fix, for another bug... When running NeXuS processing, GudPy was crashing due to an issue with incrementing the progress bar.