### PR TITLE
Fix Windows PyInstaller Executable (2)

### DIFF
--- a/gudpy.spec
+++ b/gudpy.spec
@@ -8,7 +8,7 @@ binaries = [
 block_cipher = None
 import sys
 
-main = 'gudpy/__main__.py'
+main = os.path.join('gudpy', '__main__.py')
 pathex = [main, 'gudpy']
 data = [(os.path.join("bin", "StartupFiles"), os.path.join("bin", "StartupFiles")), (os.path.join("bin", "configs"), os.path.join("bin", "configs"))]
 ui = [(os.path.join("gudpy", "gui", "widgets", "ui_files"), "ui_files"), (os.path.join("gudpy", "gui", "widgets", "resources"), "resources")]


### PR DESCRIPTION
Reimplement of below fix to most recent GudPy Main branch.


I believe this PR should fix the issues with the Windows build currently, although I don't have a Windows machine to test with!

Aims to close https://github.com/disorderedmaterials/GudPy/issues/376.