### PR TITLE
Safe format QMessages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ resources_rc.py
 *.transnofit01
 *.rebinq01
 *.vanrat
+/.vs
+/env/Scripts

--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -2040,7 +2040,7 @@ class GudPyMainWindow(QMainWindow):
         if self.error:
             QMessageBox.critical(
                 self.mainWidget, "GudPy Error",
-                self.error
+                repr(self.error)
             )
             self.error = ""
             self.queue = Queue()
@@ -2048,7 +2048,7 @@ class GudPyMainWindow(QMainWindow):
             if self.warning:
                 QMessageBox.warning(
                     self.mainWidget, "GudPy Warning",
-                    self.warning
+                    repr(self.warning)
                 )
                 self.warning = ""
             self.setControlsEnabled(True)


### PR DESCRIPTION
On Windows at least, GudPy can hang when trying to display a `QMessageBox` with output from a process (e.g. `purge_det`) that has escape sequences in it that Windows doesn't understand.

This PR encloses the error or warning text in `repr()` which safe-formats it and enables `QMessageBox` to display it correctly.