### PR TITLE
Continuous CI++

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v1
+    - name: Get Code Version
+      uses: "./.github/workflows/get-version"
     - name: "Build (${{ matrix.os }})"
       uses: "./.github/workflows/build"
     - name: "Package (${{ matrix.os }})"

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -50,3 +50,19 @@ jobs:
       uses: "./.github/workflows/build"
     - name: "Package (${{ matrix.os }})"
       uses: "./.github/workflows/package"
+
+  Publish:
+    needs: BuildPackage
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Get Code Version
+      uses: "./.github/workflows/get-version"
+    - name: "Publish"
+      uses: "./.github/workflows/publish"
+      with:
+        harborTag: "latest"
+      env:
+        HARBOR_USER: ${{ secrets.HARBOR_USER }}
+        HARBOR_SECRET: ${{ secrets.HARBOR_SECRET }}


### PR DESCRIPTION
This PR fixes a few things with the `continuous` pipeline:

- Code version was not set in the pipeline so artifacts were not correctly renamed for publication
- A publishing step did not exist, so no artifacts were pushed to Harbor

Of course, there's no way of testing this until it gets merged back in to `main`!