### PR TITLE
Separate Test Publishing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,14 @@ jobs:
     - name: "Test (${{ matrix.os }})"
       uses: "./.github/workflows/test"
 
+  TestResults:
+    needs: Test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+    - name: Publish Test Results
+      uses: "./.github/workflows/testresults"
+
   BuildPackage:
     needs: Test
     strategy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,6 +39,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v3
     - name: Publish Test Results
       uses: "./.github/workflows/testresults"
 

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -39,7 +39,7 @@ runs:
 
   - name: Upload Test Results
     if: always()
-    uses: actions/upload-artifact@v2
+    uses: actions/upload-artifact@v3
     with:
       name: testResults
       path: results

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -33,18 +33,17 @@ runs:
     run: |
       cd gudpy
       nose2 --with-coverage --coverage-report xml --plugin nose2.plugins.junitxml --junit-xml test
+      ls nose2-*
 
-  - name: Publish Test Results
-    if: always() && runner.os == 'Linux'
-    uses: EnricoMi/publish-unit-test-result-action@v2
-    with:
-      junit_files: 'gudpy/nose2-*.xml'
+      mkdir ../results
+      mv nose2-* ../results
 
-  - name: Publish Test Results
-    if: always() && runner.os != 'Linux'
-    uses: EnricoMi/publish-unit-test-result-action/composite@v2
+  - name: Upload Test Results
+    if: always()
+    uses: actions/upload-artifact@v2
     with:
-      junit_files: 'gudpy/nose2-*.xml'
+      name: testResults
+      path: results
 
   - name: Publish Code Coverage
     if: always() && runner.os == 'Linux'

--- a/.github/workflows/test/action.yml
+++ b/.github/workflows/test/action.yml
@@ -33,10 +33,9 @@ runs:
     run: |
       cd gudpy
       nose2 --with-coverage --coverage-report xml --plugin nose2.plugins.junitxml --junit-xml test
-      ls nose2-*
 
       mkdir ../results
-      mv nose2-* ../results
+      mv nose2-junit.xml ../results/nose2-junit-${{ runner.os }}.xml
 
   - name: Upload Test Results
     if: always()

--- a/.github/workflows/testresults/action.yml
+++ b/.github/workflows/testresults/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
 
   - name: Download Test Results
-    uses: actions/download-artifact@v2
+    uses: actions/download-artifact@v3
     with:
       name: testResults
       path: results

--- a/.github/workflows/testresults/action.yml
+++ b/.github/workflows/testresults/action.yml
@@ -1,0 +1,16 @@
+name: TestResults
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Download Test Results
+    uses: actions/download-artifact@v2
+    with:
+      name: testResults
+      path: results
+
+  - name: Publish Test Results
+    uses: EnricoMi/publish-unit-test-result-action/composite@v2
+    with:
+      junit_files: results/nose2-*.xml

--- a/.github/workflows/testresults/action.yml
+++ b/.github/workflows/testresults/action.yml
@@ -13,4 +13,4 @@ runs:
   - name: Publish Test Results
     uses: EnricoMi/publish-unit-test-result-action/composite@v2
     with:
-      junit_files: results/nose2-*.xml
+      junit_files: results/nose2-junit-*.xml


### PR DESCRIPTION
A PR to fix a clash when publishing test results.  This would occasionally fail if, coincidentally, more than one runner from a different OS tried to publish its results simultaneously.

As recommended by the author of the action to publish test results, this is now done in bulk by a single task.