### PR TITLE
Update Continuous Release Version

### DIFF
--- a/.github/workflows/get-externals/action.yml
+++ b/.github/workflows/get-externals/action.yml
@@ -42,7 +42,6 @@ runs:
     shell: bash
     if: runner.os == 'MacOS'
     run: |
-      # curl -L https://github.com/disorderedmaterials/Gudrun/releases/download/${{ env.gudrunTag }}/binaries-${{ env.gudrunTag }}-osx.zip > gudrun-binaries.zip
       curl -L https://github.com/disorderedmaterials/ModEx/releases/download/${{ env.modexTag }}/binaries-${{ env.modexTag }}-osx.zip > modex-binaries.zip
   - name: Retrieve Externals (Windows)
     shell: bash

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -45,7 +45,7 @@ runs:
       echo "Release tag will be: continuous"
       echo "Release name will be: 'Continuous (${{ env.gudPyVersion }})'"
       export GITHUB_TOKEN=${{ github.token }}
-      ./update-release -r disorderedmaterials/gudpy -t continuous -n "Continuous (${{ env.gudPyVersion }})" -b "Continuous release from \`main\` branch. Built $(date)." packages/*
+      ./update-release -r disorderedmaterials/gudpy -t continuous -p -e -u -n "Continuous (${{ env.gudPyVersion }})" -b "Continuous release from \`main\` branch. Built $(date)." packages/*
 
   - name: Publish on Harbor (Release)
     if: ${{ inputs.publish == 'true' && inputs.isRelease == 'true' }}

--- a/gudpy.spec
+++ b/gudpy.spec
@@ -1,5 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
-VERSION = "0.4.0"
+VERSION = "0.5.0"
 binaries = [
     (os.path.join("bin", f), '.')
     for f in os.listdir("bin")


### PR DESCRIPTION
This PR bumps the version of the continuous (development) release to `0.5.0` in order to distinguish it from the current release (`0.4.0`).

It also fixes (again) the publishing action which didn't update the continuous build correctly due to some missing flags.