### PR TITLE
Update modex version

### DIFF
--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -9,7 +9,7 @@ inputs:
     default: 2022.4
   modexTag:
     type: string
-    default: 0.1.2
+    default: 0.1.4
   hdf5tag:
     type: string
     default: hdf5-1_10_7

--- a/gudpy.spec
+++ b/gudpy.spec
@@ -1,5 +1,5 @@
 # -*- mode: python ; coding: utf-8 -*-
-VERSION = "0.5.0"
+VERSION = "0.4.0"
 binaries = [
     (os.path.join("bin", f), '.')
     for f in os.listdir("bin")


### PR DESCRIPTION
Update the main branch to use new version of ModEx (release branch 0.3.7 also created and pushed).