### PR TITLE
Update Singularity Packaging for 22.04

### DIFF
--- a/.github/workflows/package/action.yml
+++ b/.github/workflows/package/action.yml
@@ -46,7 +46,7 @@ runs:
     if: runner.os == 'Linux'
     shell: bash
     run: |
-      sudo ${SINGULARITY_ROOT}/bin/singularity build dist/GudPy-${{ env.gudPyVersion }}.sif ci/singularity/ubuntu20.04.def
+      sudo ${SINGULARITY_ROOT}/bin/singularity build dist/GudPy-${{ env.gudPyVersion }}.sif ci/singularity/ubuntu22.04.def
 
   - name: Upload Artifacts (Linux)
     if: runner.os == 'Linux'

--- a/.github/workflows/setup/action.yml
+++ b/.github/workflows/setup/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: 3.9
   gudrunTag:
     type: string
-    default: 2022.4
+    default: 2023.1
   modexTag:
     type: string
     default: 0.1.4

--- a/ci/singularity/ubuntu22.04.def
+++ b/ci/singularity/ubuntu22.04.def
@@ -8,16 +8,16 @@ From: ubuntu:22.04
 %post
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
-    apt-get install python3.9 python3-distutils curl build-essential libx11-xcb-dev libglu1-mesa-dev libxkbcommon0 libglx0 libfontconfig libglib2.0-0 libdbus-1-3 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0 libgfortran5 -y && rm -rf /var/lib/apt/lists/*
-    curl https://bootstrap.pypa.io/get-pip.py | python3.9
-    python3.9 -m pip install -r requirements.txt
+    apt-get install python3.10 python3-distutils curl build-essential libx11-xcb-dev libglu1-mesa-dev libxkbcommon0 libglx0 libfontconfig libglib2.0-0 libdbus-1-3 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0 libgfortran5 -y && rm -rf /var/lib/apt/lists/*
+    curl https://bootstrap.pypa.io/get-pip.py | python3
+    python3 -m pip install -r requirements.txt
     rm requirements.txt
-    cd /usr/local/lib/python3.9/dist-packages/PySide6
+    cd /usr/local/lib/python3.10/dist-packages/PySide6
     ls | grep .so | grep -v -e "QtCore.*" -e "QtGui.*" -e "QtCharts.*" -e "QtWidgets.*" -e "libpyside6" -e "libshiboken6" -e "QtUiTools" | xargs rm
     cd Qt/lib
     strip --remove-section=.note.ABI-tag libQt6Core.so.6 # Needed for CentOS 7
     cd
-    python3.9 -m pip uninstall pip -y
+    python3 -m pip uninstall pip -y
     apt-get remove curl -y
     unset DEBIAN_FRONTEND
     
@@ -39,10 +39,10 @@ From: ubuntu:22.04
 
 %runscript
     # If the container is executed, this line will be run.
-    python3.9 /opt/GudPy/gudpy
+    python3.10 /opt/GudPy/gudpy
 
 %apphelp GudPy
     GudPy GUI version.
 
 %apprun GudPy
-    python3.9 /opt/GudPy/gudpy
+    python3 /opt/GudPy/gudpy

--- a/ci/singularity/ubuntu22.04.def
+++ b/ci/singularity/ubuntu22.04.def
@@ -8,7 +8,7 @@ From: ubuntu:22.04
 %post
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
-    apt-get install python3.10 python3-distutils curl build-essential libx11-xcb-dev libglu1-mesa-dev libxkbcommon0 libglx0 libfontconfig libglib2.0-0 libdbus-1-3 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0 libgfortran5 -y && rm -rf /var/lib/apt/lists/*
+    apt-get install python3.10 python3-distutils curl build-essential libx11-xcb-dev libglu1-mesa-dev libxkbcommon0 libglx0 libfontconfig libglib2.0-0 libdbus-1-3 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0 libgfortran5 libegl-dev libegl-mesa0 -y && rm -rf /var/lib/apt/lists/*
     curl https://bootstrap.pypa.io/get-pip.py | python3
     python3 -m pip install -r requirements.txt
     rm requirements.txt

--- a/ci/singularity/ubuntu22.04.def
+++ b/ci/singularity/ubuntu22.04.def
@@ -1,0 +1,48 @@
+Bootstrap: library
+From: ubuntu:22.04
+
+%files
+
+    ./requirements.txt requirements.txt
+
+%post
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install python3.9 python3-distutils curl build-essential libx11-xcb-dev libglu1-mesa-dev libxkbcommon0 libglx0 libfontconfig libglib2.0-0 libdbus-1-3 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0 libgfortran5 -y && rm -rf /var/lib/apt/lists/*
+    curl https://bootstrap.pypa.io/get-pip.py | python3.9
+    python3.9 -m pip install -r requirements.txt
+    rm requirements.txt
+    cd /usr/local/lib/python3.9/dist-packages/PySide6
+    ls | grep .so | grep -v -e "QtCore.*" -e "QtGui.*" -e "QtCharts.*" -e "QtWidgets.*" -e "libpyside6" -e "libshiboken6" -e "QtUiTools" | xargs rm
+    cd Qt/lib
+    strip --remove-section=.note.ABI-tag libQt6Core.so.6 # Needed for CentOS 7
+    cd
+    python3.9 -m pip uninstall pip -y
+    apt-get remove curl -y
+    unset DEBIAN_FRONTEND
+    
+
+%help
+
+    A singularity container for GudPy.
+
+%setup
+    mkdir ${SINGULARITY_ROOTFS}/opt/GudPy
+
+%files
+
+    ./gudpy /opt/GudPy
+    ./bin /opt/GudPy
+
+%environment
+    export SIF=1
+
+%runscript
+    # If the container is executed, this line will be run.
+    python3.9 /opt/GudPy/gudpy
+
+%apphelp GudPy
+    GudPy GUI version.
+
+%apprun GudPy
+    python3.9 /opt/GudPy/gudpy


### PR DESCRIPTION
This PR updates the Singularity container to be based on Ubuntu 22.04, matching the GHA build agents.  This solves issues with mismatched glibc library versions observed on IDAaaS.

The Gudrun version brought in is also bumped to 2023.1.