### PR TITLE
Fix Singularity 22.04

### DIFF
--- a/ci/singularity/ubuntu22.04.def
+++ b/ci/singularity/ubuntu22.04.def
@@ -8,7 +8,7 @@ From: ubuntu:22.04
 %post
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
-    apt-get install python3.10 python3-distutils curl build-essential libx11-xcb-dev libglu1-mesa-dev libxkbcommon0 libglx0 libfontconfig libglib2.0-0 libdbus-1-3 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-randr libxcb-shape0 libgfortran5 libegl-dev libegl-mesa0 -y && rm -rf /var/lib/apt/lists/*
+    apt-get install python3.10 python3-distutils curl build-essential libx11-xcb-dev libglu1-mesa-dev libxkbcommon0 libglx0 libfontconfig libglib2.0-0 libdbus-1-3 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-randr0 libxcb-shape0 libgfortran5 libegl-dev libegl-mesa0 -y && rm -rf /var/lib/apt/lists/*
     curl https://bootstrap.pypa.io/get-pip.py | python3
     python3 -m pip install -r requirements.txt
     rm requirements.txt

--- a/ci/singularity/ubuntu22.04.def
+++ b/ci/singularity/ubuntu22.04.def
@@ -8,7 +8,7 @@ From: ubuntu:22.04
 %post
     export DEBIAN_FRONTEND=noninteractive
     apt-get update
-    apt-get install python3.10 python3-distutils curl build-essential libx11-xcb-dev libglu1-mesa-dev libxkbcommon0 libglx0 libfontconfig libglib2.0-0 libdbus-1-3 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-shape0 libgfortran5 libegl-dev libegl-mesa0 -y && rm -rf /var/lib/apt/lists/*
+    apt-get install python3.10 python3-distutils curl build-essential libx11-xcb-dev libglu1-mesa-dev libxkbcommon0 libglx0 libfontconfig libglib2.0-0 libdbus-1-3 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-render-util0 libxcb-randr libxcb-shape0 libgfortran5 libegl-dev libegl-mesa0 -y && rm -rf /var/lib/apt/lists/*
     curl https://bootstrap.pypa.io/get-pip.py | python3
     python3 -m pip install -r requirements.txt
     rm requirements.txt


### PR DESCRIPTION
A quick PR to fix the singularity packaging which was missing a single library.

This is mostly just for information.  I'll go ahead and rerun the last release with this patch applied.