### PR TITLE
Improved error handling

### DIFF
--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -693,7 +693,9 @@ class GudPyMainWindow(QMainWindow):
             self.gudrunFile.instrument = GudrunFile(
                 configurationDialog.configuration, config_=True
             ).instrument
-            self.gudrunFile.instrument.dataFileType = configurationDialog.dataFileType
+            self.gudrunFile.instrument.dataFileType = (
+                configurationDialog.dataFileType
+            )
             self.updateWidgets()
 
     def updateFromFile(self):

--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -693,6 +693,7 @@ class GudPyMainWindow(QMainWindow):
             self.gudrunFile.instrument = GudrunFile(
                 configurationDialog.configuration, config_=True
             ).instrument
+            self.gudrunFile.instrument.dataFileType = configurationDialog.dataFileType
             self.updateWidgets()
 
     def updateFromFile(self):

--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -641,7 +641,6 @@ class GudPyMainWindow(QMainWindow):
                 self.gudrunFile = GudrunFile(path=path)
                 self.updateWidgets()
                 self.mainWidget.setWindowTitle(self.gudrunFile.path + " [*]")
-
             except ParserException as e:
                 QMessageBox.critical(self.mainWidget, "GudPy Error", str(e))
 

--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -641,6 +641,7 @@ class GudPyMainWindow(QMainWindow):
                 self.gudrunFile = GudrunFile(path=path)
                 self.updateWidgets()
                 self.mainWidget.setWindowTitle(self.gudrunFile.path + " [*]")
+
             except ParserException as e:
                 QMessageBox.critical(self.mainWidget, "GudPy Error", str(e))
 
@@ -1257,6 +1258,9 @@ class GudPyMainWindow(QMainWindow):
         )
 
     def nexusProcessing(self):
+        if not self.checkFilesExist_():
+            return
+
         self.setControlsEnabled(False)
         nexusProcessingDialog = NexusProcessingDialog(
             self.gudrunFile, self.mainWidget
@@ -1742,7 +1746,6 @@ class GudPyMainWindow(QMainWindow):
             self.gudrunFile.write_out(path=autosavePath)
 
     def setModified(self):
-
         if not self.modified:
             if self.gudrunFile.path:
                 self.modified = True

--- a/gudpy/gui/widgets/dialogs/configuration_dialog.py
+++ b/gudpy/gui/widgets/dialogs/configuration_dialog.py
@@ -110,7 +110,7 @@ class ConfigurationDialog(QDialog):
 
     def handleDataFileTypeChanged(self, index):
         """
-        Sets file type upon change
+        Update data file type
         """
         self.dataFileType = self.widget.dataFileTypeCombo.itemText(
             index

--- a/gudpy/gui/widgets/dialogs/configuration_dialog.py
+++ b/gudpy/gui/widgets/dialogs/configuration_dialog.py
@@ -63,7 +63,7 @@ class ConfigurationDialog(QDialog):
             dataFileTypes.index(self.dataFileType)
         )
 
-        self.widget.dataFileTypeCombo.currentIndexChanged.connect(
+        self.widget.dataFileTypeCombo.currentTextChanged.connect(
             self.handleDataFileTypeChanged
         )
 
@@ -108,13 +108,11 @@ class ConfigurationDialog(QDialog):
             open(self.configuration, "r").readlines()[-1]
         )
 
-    def handleDataFileTypeChanged(self, index):
+    def handleDataFileTypeChanged(self, comboText):
         """
         Update data file type
         """
-        self.dataFileType = self.widget.dataFileTypeCombo.itemText(
-            index
-        )
+        self.dataFileType = comboText
 
     def cancel(self):
         self.cancelled = True

--- a/gudpy/gui/widgets/dialogs/configuration_dialog.py
+++ b/gudpy/gui/widgets/dialogs/configuration_dialog.py
@@ -27,6 +27,7 @@ class ConfigurationDialog(QDialog):
         super(ConfigurationDialog, self).__init__(parent=parent)
         self.parent = parent
         self.configuration = None
+        self.dataFileType = "raw"
         self.cancelled = False
         self.initComponents()
         self.loadConfigurations()
@@ -53,6 +54,17 @@ class ConfigurationDialog(QDialog):
         self.widget.setWindowTitle("Select Configuration")
         self.widget.configList.currentItemChanged.connect(
             self.setConfiguration
+        )
+
+        # Sets the combo box options
+        dataFileTypes = ["raw", "sav", "txt", "nxs", "*"]
+        self.widget.dataFileTypeCombo.addItems(dataFileTypes)
+        self.widget.dataFileTypeCombo.setCurrentIndex(
+            dataFileTypes.index(self.dataFileType)
+        )
+
+        self.widget.dataFileTypeCombo.currentIndexChanged.connect(
+            self.handleDataFileTypeChanged
         )
 
         self.widget.buttonBox.rejected.connect(
@@ -94,6 +106,14 @@ class ConfigurationDialog(QDialog):
         )
         self.widget.configDescriptionTextEdit.setText(
             open(self.configuration, "r").readlines()[-1]
+        )
+
+    def handleDataFileTypeChanged(self, index):
+        """
+        Sets file type upon change
+        """
+        self.dataFileType = self.widget.dataFileTypeCombo.itemText(
+            index
         )
 
     def cancel(self):

--- a/gudpy/gui/widgets/slots/instrument_slots.py
+++ b/gudpy/gui/widgets/slots/instrument_slots.py
@@ -31,17 +31,6 @@ class InstrumentSlots():
             dataFileTypes.index(self.instrument.dataFileType)
         )
 
-        # Enable Nexus Processing if data file type is nxs
-        self.widget.nexusDefintionFileLineEdit.setEnabled(
-            self.instrument.dataFileType in ["nxs", "NXS"]
-        )
-        self.widget.browseNexusDefinitionButton.setEnabled(
-            self.instrument.dataFileType in ["nxs", "NXS"]
-        )
-        self.widget.runNexusProcessing.setEnabled(
-            self.instrument.dataFileType in ["nxs", "NXS"]
-        )
-
         self.widget.detCalibrationLineEdit.setText(
             self.instrument.detectorCalibrationFileName
         )
@@ -164,6 +153,11 @@ class InstrumentSlots():
             self.instrument.nxsDefinitionFile
         )
 
+        # Enable Nexus Processing if data file type is nxs
+        self.widget.runNexusProcessing.setEnabled(
+            self.instrument.dataFileType in ["nxs", "NXS"]
+        )
+        
         self.widget.nexusDefintionFileLineEdit.setEnabled(
             self.instrument.dataFileType in ["nxs", "NXS"]
         )

--- a/gudpy/gui/widgets/slots/instrument_slots.py
+++ b/gudpy/gui/widgets/slots/instrument_slots.py
@@ -31,6 +31,17 @@ class InstrumentSlots():
             dataFileTypes.index(self.instrument.dataFileType)
         )
 
+        # Enable Nexus Processing if data file type is nxs
+        self.widget.nexusDefintionFileLineEdit.setEnabled(
+            self.instrument.dataFileType in ["nxs", "NXS"]
+        )
+        self.widget.browseNexusDefinitionButton.setEnabled(
+            self.instrument.dataFileType in ["nxs", "NXS"]
+        )
+        self.widget.runNexusProcessing.setEnabled(
+            self.instrument.dataFileType in ["nxs", "NXS"]
+        )
+
         self.widget.detCalibrationLineEdit.setText(
             self.instrument.detectorCalibrationFileName
         )

--- a/gudpy/gui/widgets/slots/instrument_slots.py
+++ b/gudpy/gui/widgets/slots/instrument_slots.py
@@ -157,7 +157,7 @@ class InstrumentSlots():
         self.widget.runNexusProcessing.setEnabled(
             self.instrument.dataFileType in ["nxs", "NXS"]
         )
-        
+
         self.widget.nexusDefintionFileLineEdit.setEnabled(
             self.instrument.dataFileType in ["nxs", "NXS"]
         )

--- a/gudpy/gui/widgets/ui_files/configsDialog.ui
+++ b/gudpy/gui/widgets/ui_files/configsDialog.ui
@@ -37,6 +37,51 @@
      </layout>
     </widget>
    </item>
+   
+    <item>
+   <layout class="QHBoxLayout" name="horizontalLayout_configs">
+
+    <item>
+    <widget class="QLabel" name="dataFileTypeLabel">
+    <property name="sizePolicy">
+    <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+    </sizepolicy>
+    </property>
+    <property name="minimumSize">
+    <size>
+        <width>0</width>
+        <height>0</height>
+    </size>
+    </property>
+    <property name="text">
+    <string>Data File Type</string>
+    </property>
+    </widget>
+    </item>
+
+   <item>
+   <widget class="QComboBox" name="dataFileTypeCombo">
+    <property name="sizePolicy">
+    <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+    </sizepolicy>
+    </property>
+    <property name="minimumSize">
+    <size>
+        <width>0</width>
+        <height>0</height>
+    </size>
+    </property>
+    </widget>
+   </item>
+
+   </layout>
+    </item>
+
+
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="layoutDirection">

--- a/gudpy/gui/widgets/ui_files/mainWindow.ui
+++ b/gudpy/gui/widgets/ui_files/mainWindow.ui
@@ -212,6 +212,9 @@
                  </item>
                  <item row="10" column="1">
                   <widget class="QComboBox" name="dataFileTypeCombo">
+                    <property name="enabled">
+                      <bool>false</bool>
+                    </property>
                    <property name="sizePolicy">
                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                      <horstretch>0</horstretch>


### PR DESCRIPTION
- File existence checking done before Nexus Processing dialog opens (stops application from crashing)
- Option to change data file types is disabled as this can cause users to set an inconsistent file type and cause a crash
- Users can set data file type when creating a new input file (it used to restrict it to raw only)

Closes #432