### PR TITLE
Improved safety of NeXus Processing temp directory

### DIFF
--- a/gudpy/core/nexus_processing.py
+++ b/gudpy/core/nexus_processing.py
@@ -252,7 +252,7 @@ class NexusProcessing:
         self.sample = None
         self.useTempDataFileDir = False
         self.interpolate = False
-        self.tmp = tempfile.TemporaryDirectory()
+        self.tmp = None
         self.path = "modex.cfg"
         self.goodFrameThreshold = 0
 
@@ -324,13 +324,7 @@ class NexusProcessing:
             Should processing be headless?
         """
 
-        # Cleanup temp directory.
-        for f in os.listdir(self.tmp.name):
-            fp = os.path.join(self.tmp.name, f)
-            if os.path.isfile(fp):
-                os.remove(fp)
-            elif os.path.isdir(fp):
-                shutil.rmtree(fp)
+        self.tmp = tempfile.TemporaryDirectory()
 
         self.useTempDataFileDir = useTempDataFileDir
         # List to hold tasks, in the case of headful preprocessing.

--- a/gudpy/core/nexus_processing.py
+++ b/gudpy/core/nexus_processing.py
@@ -386,8 +386,6 @@ class NexusProcessing:
             self.dataFileDir = os.path.join(self.tmp.name, "data")
             # If headless, copy all the data files into this new directory.
             if headless:
-                if os.path.exists(self.dataFileDir):
-                    shutil.rmtree(self.dataFileDir)
                 os.makedirs(self.dataFileDir)
                 for dataFile in self.ref.normalisation.dataFiles.dataFiles:
                     self.copyfile(
@@ -438,10 +436,6 @@ class NexusProcessing:
                         )
             # Otherwise, append the copies as tasks.
             else:
-                if os.path.exists(os.path.join(self.dataFileDir)):
-                    tasks.append(
-                        (shutil.rmtree, [os.path.join(self.dataFileDir)])
-                    )
                 tasks.append(
                     (
                         os.makedirs,

--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -1318,6 +1318,7 @@ class GudPyMainWindow(QMainWindow):
                 self.mainWidget, "GudPy Error",
                 self.error
             )
+            self.gudrunFile.nexus_processing.tmp.cleanup()
 
     def progressNexusProcess(self):
         progress = self.progressIncrementDCS(
@@ -1401,6 +1402,7 @@ class GudPyMainWindow(QMainWindow):
             gudrunFile=self.gudrunFile.nexus_processing.gudrunFile,
             keyMap=self.keyMap
         )
+        self.gudrunFile.nexus_processing.tmp.cleanup()
 
     def iterateGudrun(self, dialog, name):
         if not self.checkFilesExist_():


### PR DESCRIPTION
Small change to how the temporary directory is managed in NeXus processing to improve safety.

- New temporary directory is created with each NeXus processing run
- Omits need for `shutil.rmtree'
- Deletes directory once NeXus run is complete