### PR TITLE
NeXuS Handling Fix 1 / ???

### DIFF
--- a/gudpy/gui/widgets/dialogs/nexus_processing_dialog.py
+++ b/gudpy/gui/widgets/dialogs/nexus_processing_dialog.py
@@ -94,11 +94,13 @@ class NexusProcessingDialog(QDialog):
 
             start = (
                 datetime.today() if not fp.__contains__("/raw_data_1/start_time") else
-                datetime.strptime(fp["/raw_data_1/start_time"][()][0].decode("utf8"), "%Y-%m-%dT%H:%M:%S")
+                datetime.strptime(fp["/raw_data_1/start_time"]
+                                  [()][0].decode("utf8"), "%Y-%m-%dT%H:%M:%S")
             )
             end = (
                 datetime.today() if not fp.__contains__("/raw_data_1/end_time") else
-                datetime.strptime(fp["/raw_data_1/end_time"][()][0].decode("utf8"), "%Y-%m-%dT%H:%M:%S")
+                datetime.strptime(fp["/raw_data_1/end_time"]
+                                  [()][0].decode("utf8"), "%Y-%m-%dT%H:%M:%S")
             )
             self.start = QDateTime.fromString(
                 start.isoformat(), Qt.ISODateWithMs

--- a/gudpy/gui/widgets/dialogs/nexus_processing_dialog.py
+++ b/gudpy/gui/widgets/dialogs/nexus_processing_dialog.py
@@ -94,7 +94,7 @@ class NexusProcessingDialog(QDialog):
 
             start = (
                 datetime.today()
-                if not fp.__contains__("/raw_data_1/start_time")
+                if not "/raw_data_1/start_time" in fp
                 else datetime.strptime(
                     fp["/raw_data_1/start_time"][()][0].decode("utf8"),
                     "%Y-%m-%dT%H:%M:%S",
@@ -102,7 +102,7 @@ class NexusProcessingDialog(QDialog):
             )
             end = (
                 datetime.today()
-                if not fp.__contains__("/raw_data_1/end_time")
+                if not "/raw_data_1/end_time" in fp
                 else datetime.strptime(
                     fp["/raw_data_1/end_time"][()][0].decode("utf8"),
                     "%Y-%m-%dT%H:%M:%S",

--- a/gudpy/gui/widgets/dialogs/nexus_processing_dialog.py
+++ b/gudpy/gui/widgets/dialogs/nexus_processing_dialog.py
@@ -94,7 +94,7 @@ class NexusProcessingDialog(QDialog):
 
             start = (
                 datetime.today()
-                if not "/raw_data_1/start_time" in fp
+                if "/raw_data_1/start_time" not in fp
                 else datetime.strptime(
                     fp["/raw_data_1/start_time"][()][0].decode("utf8"),
                     "%Y-%m-%dT%H:%M:%S",
@@ -102,7 +102,7 @@ class NexusProcessingDialog(QDialog):
             )
             end = (
                 datetime.today()
-                if not "/raw_data_1/end_time" in fp
+                if "/raw_data_1/end_time" not in fp
                 else datetime.strptime(
                     fp["/raw_data_1/end_time"][()][0].decode("utf8"),
                     "%Y-%m-%dT%H:%M:%S",

--- a/gudpy/gui/widgets/dialogs/nexus_processing_dialog.py
+++ b/gudpy/gui/widgets/dialogs/nexus_processing_dialog.py
@@ -93,21 +93,25 @@ class NexusProcessingDialog(QDialog):
             self.widget.upperSpecSpinBox.setRange(min(spectra), max(spectra))
 
             start = (
-                datetime.today() if not fp.__contains__("/raw_data_1/start_time") else
-                datetime.strptime(fp["/raw_data_1/start_time"]
-                                  [()][0].decode("utf8"), "%Y-%m-%dT%H:%M:%S")
+                datetime.today()
+                if not fp.__contains__("/raw_data_1/start_time")
+                else datetime.strptime(
+                    fp["/raw_data_1/start_time"][()][0].decode("utf8"),
+                    "%Y-%m-%dT%H:%M:%S",
+                )
             )
             end = (
-                datetime.today() if not fp.__contains__("/raw_data_1/end_time") else
-                datetime.strptime(fp["/raw_data_1/end_time"]
-                                  [()][0].decode("utf8"), "%Y-%m-%dT%H:%M:%S")
+                datetime.today()
+                if not fp.__contains__("/raw_data_1/end_time")
+                else datetime.strptime(
+                    fp["/raw_data_1/end_time"][()][0].decode("utf8"),
+                    "%Y-%m-%dT%H:%M:%S",
+                )
             )
             self.start = QDateTime.fromString(
                 start.isoformat(), Qt.ISODateWithMs
             )
-            self.end = QDateTime.fromString(
-                end.isoformat(), Qt.ISODateWithMs
-            )
+            self.end = QDateTime.fromString(end.isoformat(), Qt.ISODateWithMs)
 
         self.widget.lowerSpecSpinBox.setValue(min(spectra))
         self.widget.upperSpecSpinBox.setValue(max(spectra))

--- a/gudpy/gui/widgets/dialogs/nexus_processing_dialog.py
+++ b/gudpy/gui/widgets/dialogs/nexus_processing_dialog.py
@@ -83,19 +83,22 @@ class NexusProcessingDialog(QDialog):
             )
         ) as fp:
 
-            spectra = fp["/raw_data_1/detector_1/spectrum_index"][()][
-                :
-            ].tolist()
+            if fp.__contains__("/raw_data_1/detector_1/spectrum_index"):
+                spectra = fp["/raw_data_1/detector_1/spectrum_index"][()][
+                    :
+                ].tolist()
+            else:
+                spectra = [0]
             self.widget.lowerSpecSpinBox.setRange(min(spectra), max(spectra))
             self.widget.upperSpecSpinBox.setRange(min(spectra), max(spectra))
 
-            start = fp["/raw_data_1/start_time"][()][0].decode("utf8")
-            end = fp["/raw_data_1/end_time"][()][0].decode("utf8")
             start = (
-                datetime.strptime(start, "%Y-%m-%dT%H:%M:%S")
+                datetime.today() if not fp.__contains__("/raw_data_1/start_time") else
+                datetime.strptime(fp["/raw_data_1/start_time"][()][0].decode("utf8"), "%Y-%m-%dT%H:%M:%S")
             )
             end = (
-                datetime.strptime(end, "%Y-%m-%dT%H:%M:%S")
+                datetime.today() if not fp.__contains__("/raw_data_1/end_time") else
+                datetime.strptime(fp["/raw_data_1/end_time"][()][0].decode("utf8"), "%Y-%m-%dT%H:%M:%S")
             )
             self.start = QDateTime.fromString(
                 start.isoformat(), Qt.ISODateWithMs

--- a/gudpy/gui/widgets/dialogs/nexus_processing_dialog.py
+++ b/gudpy/gui/widgets/dialogs/nexus_processing_dialog.py
@@ -83,7 +83,7 @@ class NexusProcessingDialog(QDialog):
             )
         ) as fp:
 
-            if fp.__contains__("/raw_data_1/detector_1/spectrum_index"):
+            if "/raw_data_1/detector_1/spectrum_index" in fp:
                 spectra = fp["/raw_data_1/detector_1/spectrum_index"][()][
                     :
                 ].tolist()


### PR DESCRIPTION
This PR improves the behaviour of the NeXuS processing dialog init, where if a nexus file didn't contain the necessary keys (as is the case when you're processing a previously-output ModEx nxs file), an exception would be thrown and the GUI would effectively be locked.