### PR TITLE
450 Fixing YAML parsing bug and improved error handling

### DIFF
--- a/gudpy/core/exception.py
+++ b/gudpy/core/exception.py
@@ -4,3 +4,7 @@ class ParserException(Exception):
 
 class ChemicalFormulaParserException(Exception):
     pass
+
+
+class YAMLException(Exception):
+    pass

--- a/gudpy/core/gudpy_yaml.py
+++ b/gudpy/core/gudpy_yaml.py
@@ -123,7 +123,7 @@ class YAML:
                         or "abundance" not in element
                     ):
                         raise YAMLException(
-                            "Insufficient arguements given to element"
+                            "Insufficient arguments given to element"
                             + f" {idx + 1}. Expects 'atomicSymbol', 'massNo'"
                             + " and 'abundance'"
                         )

--- a/gudpy/core/gudpy_yaml.py
+++ b/gudpy/core/gudpy_yaml.py
@@ -193,7 +193,7 @@ class YAML:
             else:
                 setattr(cls, k, type(cls.__dict__[k])(self.toBuiltin(v)))
 
-    def maskYAMLSeqtoClss(self, cls, yamlseq):
+    def maskYAMLSeqtoClass(self, cls, yamlseq):
         if isinstance(cls, Components):
             components = []
             for component in yamlseq:

--- a/gudpy/core/gudpy_yaml.py
+++ b/gudpy/core/gudpy_yaml.py
@@ -67,7 +67,7 @@ class YAML:
 
         components = Components()
         if "Components" in yamldict:
-            self.maskYAMLSeqtoClss(components, yamldict["Components"])
+            self.maskYAMLSeqtoClass(components, yamldict["Components"])
 
         normalisation = Normalisation()
         if "Normalisation" in yamldict:

--- a/gudpy/core/gudrun_file.py
+++ b/gudpy/core/gudrun_file.py
@@ -35,7 +35,7 @@ from core.enums import (
 )
 from core import config
 from core.gudpy_yaml import YAML
-from core.exception import ParserException
+from core.exception import ParserException, YAMLException
 from core.nexus_processing import NexusProcessing
 from core.gud_file import GudFile
 

--- a/gudpy/core/gudrun_file.py
+++ b/gudpy/core/gudrun_file.py
@@ -1304,19 +1304,21 @@ class GudrunFile:
                 "The path supplied is invalid.\
                  Cannot parse from an invalid path" + self.path
             )
-
-        try:
-            (
-                self.instrument,
-                self.beam,
-                self.components,
-                self.normalisation,
-                self.sampleBackgrounds,
-                config.GUI
-            ) = self.yaml.parseYaml(self.path)
-            self.format = Format.YAML
-        except Exception:
-            self.format = Format.TXT
+        if self.format == Format.YAML:
+            # YAML Files
+            try:
+                (
+                    self.instrument,
+                    self.beam,
+                    self.components,
+                    self.normalisation,
+                    self.sampleBackgrounds,
+                    config.GUI
+                ) = self.yaml.parseYaml(self.path)
+            except YAMLException as e:
+                raise ParserException(e)
+        else:
+            # TXT Files
             parsing = ""
             KEYWORDS = {
                 "INSTRUMENT": False,

--- a/gudpy/core/gudrun_file.py
+++ b/gudpy/core/gudrun_file.py
@@ -128,7 +128,7 @@ class GudrunFile:
         Create a PurgeFile from the GudrunFile, and run purge_det on it.
     """
 
-    def __init__(self, path=None, config_=False):
+    def __init__(self, path=None, format=Format.YAML, config_=False):
         """
         Constructs all the necessary attributes for the GudrunFile object.
         Calls the GudrunFile's parse method,
@@ -138,10 +138,15 @@ class GudrunFile:
         ----------
         path : str
             Path to the file.
+        format : Format enum
+            Format of the file
+        config_ : bool
+            If a new input file should be constructed from a config
         """
 
         self.path = path
         self.yaml = YAML()
+        self.format = format
 
         # Construct the outpath.
         self.outpath = "gudpy.txt"

--- a/gudpy/core/gudrun_file.py
+++ b/gudpy/core/gudrun_file.py
@@ -7,15 +7,15 @@ import re
 from copy import deepcopy
 
 from core.utils import (
-        extract_nums_from_string,
-        firstword, boolifyNum,
-        extract_ints_from_string,
-        extract_floats_from_string,
-        firstNFloats,
-        firstNInts,
-        nthfloat,
-        nthint,
-        resolve
+    extract_nums_from_string,
+    firstword, boolifyNum,
+    extract_ints_from_string,
+    extract_floats_from_string,
+    firstNFloats,
+    firstNInts,
+    nthfloat,
+    nthint,
+    resolve
 )
 from core.instrument import Instrument
 from core.beam import Beam
@@ -440,32 +440,32 @@ class GudrunFile:
                 self.instrument.detectorCalibrationFileName = match.group()
 
             match = re.search(
-                    pattern,
-                    self.instrument.groupFileName
+                pattern,
+                self.instrument.groupFileName
             )
 
             if match:
                 self.instrument.groupFileName = match.group()
 
             match = re.search(
-                    pattern,
-                    self.instrument.deadtimeConstantsFileName
+                pattern,
+                self.instrument.deadtimeConstantsFileName
             )
 
             if match:
                 self.instrument.deadtimeConstantsFileName = match.group()
 
             match = re.search(
-                    pattern,
-                    self.instrument.neutronScatteringParametersFile
+                pattern,
+                self.instrument.neutronScatteringParametersFile
             )
 
             if match:
                 self.instrument.neutronScatteringParametersFile = match.group()
 
             match = re.search(
-                    pattern,
-                    self.instrument.neutronScatteringParametersFile
+                pattern,
+                self.instrument.neutronScatteringParametersFile
             )
 
             if match:
@@ -473,10 +473,10 @@ class GudrunFile:
 
         except Exception as e:
             raise ParserException(
-                    "Whilst parsing Instrument, an exception occured."
-                    " The input file is most likely of an incorrect format, "
-                    "and some attributes were missing."
-                    f"{str(e)}"
+                "Whilst parsing Instrument, an exception occured."
+                " The input file is most likely of an incorrect format, "
+                "and some attributes were missing."
+                f"{str(e)}"
             ) from e
 
     def parseBeam(self):
@@ -556,8 +556,8 @@ class GudrunFile:
             pattern = re.compile(r"StartupFiles\S*")
 
             match = re.search(
-                    pattern,
-                    self.beam.filenameIncidentBeamSpectrumParams
+                pattern,
+                self.beam.filenameIncidentBeamSpectrumParams
             )
 
             if match:
@@ -578,9 +578,9 @@ class GudrunFile:
 
         except Exception as e:
             raise ParserException(
-                    "Whilst parsing Beam, an exception occured."
-                    " The input file is most likely of an incorrect format, "
-                    "and some attributes were missing."
+                "Whilst parsing Beam, an exception occured."
+                " The input file is most likely of an incorrect format, "
+                "and some attributes were missing."
             ) from e
 
     def parseNormalisation(self):
@@ -782,9 +782,9 @@ class GudrunFile:
 
         except Exception as e:
             raise ParserException(
-                    "Whilst parsing Normalisation, an exception occured."
-                    " The input file is most likely of an incorrect format, "
-                    "and some attributes were missing."
+                "Whilst parsing Normalisation, an exception occured."
+                " The input file is most likely of an incorrect format, "
+                "and some attributes were missing."
             ) from e
 
     def parseSampleBackground(self):
@@ -826,9 +826,9 @@ class GudrunFile:
             return sampleBackground
         except Exception as e:
             raise ParserException(
-                    "Whilst parsing Sample Background, an exception occured."
-                    " The input file is most likely of an incorrect format, "
-                    "and some attributes were missing."
+                "Whilst parsing Sample Background, an exception occured."
+                " The input file is most likely of an incorrect format, "
+                "and some attributes were missing."
             ) from e
 
     def parseSample(self):
@@ -984,7 +984,7 @@ class GudrunFile:
             while (
                     "to finish specifying wavelength range of resonance"
                     not in line
-                    ):
+            ):
                 sample.resonanceValues.append(
                     extract_floats_from_string(line)
                 )
@@ -1032,9 +1032,9 @@ class GudrunFile:
 
         except Exception as e:
             raise ParserException(
-                    "Whilst parsing Sample, an exception occured."
-                    " The input file is most likely of an incorrect format, "
-                    "and some attributes were missing."
+                "Whilst parsing Sample, an exception occured."
+                " The input file is most likely of an incorrect format, "
+                "and some attributes were missing."
             ) from e
 
     def parseContainer(self):
@@ -1177,9 +1177,9 @@ class GudrunFile:
 
         except Exception as e:
             raise ParserException(
-                    "Whilst parsing Container, an exception occured."
-                    " The input file is most likely of an incorrect format, "
-                    "and some attributes were missing."
+                "Whilst parsing Container, an exception occured."
+                " The input file is most likely of an incorrect format, "
+                "and some attributes were missing."
             ) from e
 
     def parseComponents(self):
@@ -1641,9 +1641,9 @@ class GudrunFile:
 
     def determineError(self, sample):
         gudPath = sample.dataFiles[0].replace(
-                    self.instrument.dataFileType,
-                    "gud"
-                )
+            self.instrument.dataFileType,
+            "gud"
+        )
         gudFile = GudFile(
             os.path.join(
                 self.instrument.GudrunInputFileDir, gudPath

--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -626,19 +626,27 @@ class GudPyMainWindow(QMainWindow):
         """
         Opens a QFileDialog to load an input file.
         """
-        filename, _ = QFileDialog.getOpenFileName(
+        filters = {
+            "YAML (*.yaml)": Format.YAML,
+            "Gudrun Compatible (*.txt)": Format.TXT,
+            "Sample Parameters (*.sample)": Format.TXT
+        }
+
+        filename, filter = QFileDialog.getOpenFileName(
             self.mainWidget,
             "Select Input file for GudPy",
             ".",
-            "YAML (*.yaml);;Gudrun Compatible "
-            "(*.txt);;Sample Parameters (*.sample)"
+            f"{filters.keys()[0]};;" +
+            f"{filters.keys()[1]};;" +
+            f"{filters.keys()[2]};;"
         )
+        fmt = filters[filter]
         if filename:
             try:
                 if self.gudrunFile:
                     del self.gudrunFile
                 path = self.tryLoadAutosaved(filename)
-                self.gudrunFile = GudrunFile(path=path)
+                self.gudrunFile = GudrunFile(path=path, format=fmt)
                 self.updateWidgets()
                 self.mainWidget.setWindowTitle(self.gudrunFile.path + " [*]")
             except ParserException as e:

--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -154,6 +154,7 @@ class GudPyMainWindow(QMainWindow):
     exit_()
         Exits
     """
+
     def __init__(self):
         """
         Constructs all the necessary attributes for the GudPyMainWindow object.
@@ -636,12 +637,12 @@ class GudPyMainWindow(QMainWindow):
             self.mainWidget,
             "Select Input file for GudPy",
             ".",
-            f"{filters.keys()[0]};;" +
-            f"{filters.keys()[1]};;" +
-            f"{filters.keys()[2]};;"
+            f"{list(filters.keys())[0]};;" +
+            f"{list(filters.keys())[1]};;" +
+            f"{list(filters.keys())[2]};;"
         )
-        fmt = filters[filter]
         if filename:
+            fmt = filters[filter]
             try:
                 if self.gudrunFile:
                     del self.gudrunFile
@@ -651,6 +652,10 @@ class GudPyMainWindow(QMainWindow):
                 self.mainWidget.setWindowTitle(self.gudrunFile.path + " [*]")
             except ParserException as e:
                 QMessageBox.critical(self.mainWidget, "GudPy Error", str(e))
+            except IOError:
+                QMessageBox.critical(self.mainWidget,
+                                     "GudPy Error",
+                                     "Could not open file")
 
     def saveInputFile(self):
         """
@@ -1084,9 +1089,9 @@ class GudPyMainWindow(QMainWindow):
             )
         else:
             self.makeProc(
-              dcs, self.progressDCS,
-              func=func, args=args,
-              finished=self.runGudrunFinished
+                dcs, self.progressDCS,
+                func=func, args=args,
+                finished=self.runGudrunFinished
             )
 
     def runContainersAsSamples(self):
@@ -1186,9 +1191,9 @@ class GudPyMainWindow(QMainWindow):
             )
         else:
             self.makeProc(
-              dcs, self.progressDCS,
-              func=func, args=args,
-              finished=finished
+                dcs, self.progressDCS,
+                func=func, args=args,
+                finished=finished
             )
 
     def purgeOptionsMessageBox(self, dcs, finished, func, args, text):
@@ -1215,9 +1220,9 @@ class GudPyMainWindow(QMainWindow):
             self.purgeBeforeRunning()
         elif result == messageBox.Yes:
             self.makeProc(
-              dcs, self.progressDCS,
-              func=func, args=args,
-              finished=finished
+                dcs, self.progressDCS,
+                func=func, args=args,
+                finished=finished
             )
         else:
             messageBox.close()
@@ -1354,7 +1359,7 @@ class GudPyMainWindow(QMainWindow):
                 self.queue.put(t)
             self.currentFile = 0
             self.keyMap = {
-                n+1: os.path.splitext(
+                n + 1: os.path.splitext(
                     os.path.basename(
                         self.nexusProcessingFiles[n]
                     )
@@ -1389,7 +1394,7 @@ class GudPyMainWindow(QMainWindow):
         timer.start()
         while (timer.elapsed() < 5000):
             QCoreApplication.processEvents()
-        self.nexusProcessingOutput[self.currentFile+1] = self.output
+        self.nexusProcessingOutput[self.currentFile + 1] = self.output
         self.currentFile += 1
         self.output = ""
         func, args = self.queue.get()
@@ -1453,7 +1458,7 @@ class GudPyMainWindow(QMainWindow):
             self.nextBatchProcess()
 
     def batchProcessFinished(self, ec, es):
-        self.outputBatches[self.currentIteration+1] = self.output
+        self.outputBatches[self.currentIteration + 1] = self.output
         self.output = ""
         self.currentIteration += 1
         self.nextBatchProcess()
@@ -1481,7 +1486,7 @@ class GudPyMainWindow(QMainWindow):
                     with self.queue.mutex:
                         remaining = list(self.queue.queue)
                     n = remaining.index(None)
-                    for _ in range(n+1):
+                    for _ in range(n + 1):
                         self.queue.get()
                     self.nextBatchProcess()
                 else:
@@ -1575,7 +1580,7 @@ class GudPyMainWindow(QMainWindow):
         progress = (
             currentIteration / self.numberIterations
         ) * (self.currentIteration / self.totalIterations)
-        self.mainWidget.progressBar.setValue(int(progress*100))
+        self.mainWidget.progressBar.setValue(int(progress * 100))
 
     def nextCompositionIteration(self):
         args, kwargs, sample = self.queue.get()
@@ -1666,7 +1671,7 @@ class GudPyMainWindow(QMainWindow):
             else:
                 self.iterator.gudrunFile.iterativeOrganise(
                     f"QIteration_{(self.currentIteration // 2) + 1}"
-                    )
+                )
                 self.outputIterations[self.currentIteration + 1] = self.output
         if not self.queue.empty():
             self.currentIteration += 1
@@ -1707,7 +1712,7 @@ class GudPyMainWindow(QMainWindow):
                 f" {self.currentIteration+1}/{self.numberIterations}"
             )
         elif isinstance(self.iterator, WavelengthSubtractionIterator):
-            iteration = math.ceil((self.currentIteration+1)/2)
+            iteration = math.ceil((self.currentIteration + 1) / 2)
             self.mainWidget.currentTaskLabel.setText(
                 f"{self.text}"
                 f" {iteration}/{int(self.numberIterations/2)}"
@@ -1884,7 +1889,7 @@ class GudPyMainWindow(QMainWindow):
                                     for sample in sampleBackground.samples
                                     if sample.runThisSample
                                 ]
-                                ),
+                            ),
                             *[
                                 len(sample.containers)
                                 for sample in sampleBackground.samples
@@ -1895,7 +1900,7 @@ class GudPyMainWindow(QMainWindow):
                 ]
             )
         )
-        stepSize = math.ceil(100/markers)
+        stepSize = math.ceil(100 / markers)
         progress = stepSize * sum(
             [
                 stdout.count("Got to: INSTRUMENT"),
@@ -1966,7 +1971,7 @@ class GudPyMainWindow(QMainWindow):
                 ]
             )
 
-        stepSize = math.ceil(100/len(dataFiles))
+        stepSize = math.ceil(100 / len(dataFiles))
         progress = 0
         for df in dataFiles:
             if df in stdout:
@@ -2045,7 +2050,7 @@ class GudPyMainWindow(QMainWindow):
                 RadiusIterator, DensityIterator
             )
         ):
-            self.outputIterations[self.currentIteration+1] = self.output
+            self.outputIterations[self.currentIteration + 1] = self.output
             self.sampleSlots.setSample(self.sampleSlots.sample)
         if self.iterator:
             output = self.outputIterations

--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -584,7 +584,9 @@ class GudPyMainWindow(QMainWindow):
     def updateWidgets(self, fromFile=False):
         self.widgetsRefreshing = True
         if fromFile:
-            self.gudrunFile = GudrunFile(path=self.gudrunFile.path)
+            self.gudrunFile = GudrunFile(
+                path=self.gudrunFile.path,
+                format=self.gudrunFile.format)
         self.mainWidget.gudrunFile = self.gudrunFile
         self.mainWidget.tabWidget.setVisible(True)
         self.instrumentSlots.setInstrument(self.gudrunFile.instrument)

--- a/gudpy/gui/widgets/tables/event_table.py
+++ b/gudpy/gui/widgets/tables/event_table.py
@@ -22,6 +22,7 @@ class EventModel(GudPyTableModel):
     data(index, role)
         Returns data at a given index
     """
+
     def __init__(self, h5path, spec, headers, parent):
         """
         Calls super().__init__ on the passed parameters.
@@ -39,7 +40,6 @@ class EventModel(GudPyTableModel):
         with h5.File(h5path) as fp:
             if spec in fp.keys():
                 data = sorted(fp[f"/{spec}"][()][:].tolist())
-                print(data)
             else:
                 data = []
         super(EventModel, self).__init__(data, headers, parent)
@@ -117,6 +117,7 @@ class EventTable(QTableView):
     makeModel(data)
         Creates the model using the data.
     """
+
     def __init__(self, parent):
         """
         Constructs all the necessary attributes

--- a/gudpy/test/test_gud_file.py
+++ b/gudpy/test/test_gud_file.py
@@ -231,7 +231,7 @@ class TestParseGudFile(TestCase):
                 + "/"
                 + path
             )
-        self.g = GudrunFile(dirpath)
+        self.g = GudrunFile(dirpath, format=Format.TXT)
 
         self.keepsakes = os.listdir()
 
@@ -281,9 +281,11 @@ class TestParseGudFile(TestCase):
             )
         )
         self.assertIsInstance(gf, GudFile)
-format=Format.TXT
+
     def testLoadGudFileA(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
+        g = GudrunFile(
+            "test/TestData/NIMROD-water/good_water.txt",
+            format=Format.TXT)
         g.dcs()
         gf = GudFile(
             os.path.join(
@@ -325,9 +327,11 @@ format=Format.TXT
                         )
                     except Exception:
                         raise e
-format=Format.TXT
+
     def testLoadGudFileB(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
+        g = GudrunFile(
+            "test/TestData/NIMROD-water/good_water.txt",
+            format=Format.TXT)
         g.dcs()
 
         gf = GudFile(
@@ -371,9 +375,11 @@ format=Format.TXT
                         )
                     except Exception:
                         raise e
-format=Format.TXT
+
     def testLoadGudFileC(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
+        g = GudrunFile(
+            "test/TestData/NIMROD-water/good_water.txt",
+            format=Format.TXT)
         g.dcs()
         gf = GudFile(
             os.path.join(
@@ -415,9 +421,11 @@ format=Format.TXT
                         )
                     except Exception:
                         raise e
-format=Format.TXT
+
     def testLoadGudFileD(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
+        g = GudrunFile(
+            "test/TestData/NIMROD-water/good_water.txt",
+            format=Format.TXT)
         g.dcs()
         gf = GudFile(
             os.path.join(
@@ -460,9 +468,11 @@ format=Format.TXT
                         )
                     except Exception:
                         raise e
-format=Format.TXT
+
     def testWriteGudFileA(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
+        g = GudrunFile(
+            "test/TestData/NIMROD-water/good_water.txt",
+            format=Format.TXT)
         g.dcs()
         gf = GudFile(
             os.path.join(
@@ -487,9 +497,11 @@ format=Format.TXT
 
         for v1, v2 in zip(gf.__dict__.values(), gf1.__dict__.values()):
             self.assertEqual(v1, v2)
-format=Format.TXT
+
     def testWriteGudFileB(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
+        g = GudrunFile(
+            "test/TestData/NIMROD-water/good_water.txt",
+            format=Format.TXT)
         g.dcs()
         gf = GudFile(
             os.path.join(

--- a/gudpy/test/test_gud_file.py
+++ b/gudpy/test/test_gud_file.py
@@ -5,6 +5,7 @@ from unittest import TestCase
 from core.exception import ParserException
 from core.gud_file import GudFile
 from core.gudrun_file import GudrunFile
+from core.enums import Format
 
 
 class TestParseGudFile(TestCase):
@@ -236,7 +237,8 @@ class TestParseGudFile(TestCase):
 
         copyfile(self.g.path, "test/TestData/NIMROD-water/good_water.txt")
         g = GudrunFile(
-            os.path.abspath("test/TestData/NIMROD-water/good_water.txt")
+            os.path.abspath("test/TestData/NIMROD-water/good_water.txt"),
+            Format.TXT
         )
 
         from pathlib import Path
@@ -269,7 +271,7 @@ class TestParseGudFile(TestCase):
         self.assertRaises(ParserException, GudFile, invalid_path)
 
     def testValidPath(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt")
+        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         g.dcs()
         gf = GudFile(
             os.path.join(
@@ -279,7 +281,7 @@ class TestParseGudFile(TestCase):
         self.assertIsInstance(gf, GudFile)
 
     def testLoadGudFileA(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt")
+        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         g.dcs()
         gf = GudFile(
             os.path.join(
@@ -323,7 +325,7 @@ class TestParseGudFile(TestCase):
                         raise e
 
     def testLoadGudFileB(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt")
+        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         g.dcs()
 
         gf = GudFile(
@@ -369,7 +371,7 @@ class TestParseGudFile(TestCase):
                         raise e
 
     def testLoadGudFileC(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt")
+        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         g.dcs()
         gf = GudFile(
             os.path.join(
@@ -413,7 +415,7 @@ class TestParseGudFile(TestCase):
                         raise e
 
     def testLoadGudFileD(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt")
+        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         g.dcs()
         gf = GudFile(
             os.path.join(
@@ -458,7 +460,7 @@ class TestParseGudFile(TestCase):
                         raise e
 
     def testWriteGudFileA(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt")
+        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         g.dcs()
         gf = GudFile(
             os.path.join(
@@ -485,7 +487,7 @@ class TestParseGudFile(TestCase):
             self.assertEqual(v1, v2)
 
     def testWriteGudFileB(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt")
+        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         g.dcs()
         gf = GudFile(
             os.path.join(

--- a/gudpy/test/test_gud_file.py
+++ b/gudpy/test/test_gud_file.py
@@ -238,7 +238,7 @@ class TestParseGudFile(TestCase):
         copyfile(self.g.path, "test/TestData/NIMROD-water/good_water.txt")
         g = GudrunFile(
             os.path.abspath("test/TestData/NIMROD-water/good_water.txt"),
-            Format.TXT
+            format=Format.TXT
         )
 
         from pathlib import Path
@@ -271,7 +271,9 @@ class TestParseGudFile(TestCase):
         self.assertRaises(ParserException, GudFile, invalid_path)
 
     def testValidPath(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
+        g = GudrunFile(
+            "test/TestData/NIMROD-water/good_water.txt",
+            format=Format.TXT)
         g.dcs()
         gf = GudFile(
             os.path.join(
@@ -279,7 +281,7 @@ class TestParseGudFile(TestCase):
             )
         )
         self.assertIsInstance(gf, GudFile)
-
+format=Format.TXT
     def testLoadGudFileA(self):
         g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         g.dcs()
@@ -323,7 +325,7 @@ class TestParseGudFile(TestCase):
                         )
                     except Exception:
                         raise e
-
+format=Format.TXT
     def testLoadGudFileB(self):
         g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         g.dcs()
@@ -369,7 +371,7 @@ class TestParseGudFile(TestCase):
                         )
                     except Exception:
                         raise e
-
+format=Format.TXT
     def testLoadGudFileC(self):
         g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         g.dcs()
@@ -413,7 +415,7 @@ class TestParseGudFile(TestCase):
                         )
                     except Exception:
                         raise e
-
+format=Format.TXT
     def testLoadGudFileD(self):
         g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         g.dcs()
@@ -458,7 +460,7 @@ class TestParseGudFile(TestCase):
                         )
                     except Exception:
                         raise e
-
+format=Format.TXT
     def testWriteGudFileA(self):
         g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         g.dcs()
@@ -485,7 +487,7 @@ class TestParseGudFile(TestCase):
 
         for v1, v2 in zip(gf.__dict__.values(), gf1.__dict__.values()):
             self.assertEqual(v1, v2)
-
+format=Format.TXT
     def testWriteGudFileB(self):
         g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         g.dcs()

--- a/gudpy/test/test_gudpy_io.py
+++ b/gudpy/test/test_gudpy_io.py
@@ -848,7 +848,8 @@ class TestGudPyIO(TestCase):
             os.path.join(
                 self.g.instrument.GudrunInputFileDir,
                 self.g.outpath
-            )
+            ),
+            format=Format.TXT
         )
         g1.instrument.GudrunInputFileDir = self.g.instrument.GudrunInputFileDir
         g1.write_out()
@@ -915,7 +916,7 @@ class TestGudPyIO(TestCase):
         f = open("test_data.txt", "w", encoding="utf-8")
         f.close()
         with self.assertRaises(ParserException) as cm:
-            GudrunFile("test_data.txt")
+            GudrunFile("test_data.txt", format=Format.TXT)
         self.assertEqual((
             'INSTRUMENT, BEAM and NORMALISATION'
             ' were not parsed. It\'s possible the file'
@@ -935,7 +936,7 @@ class TestGudPyIO(TestCase):
             )
 
         with self.assertRaises(ParserException) as cm:
-            GudrunFile("test_data.txt")
+            GudrunFile("test_data.txt", format=Format.TXT)
         self.assertEqual((
             'INSTRUMENT, BEAM and NORMALISATION'
             ' were not parsed. It\'s possible the file'
@@ -957,7 +958,7 @@ class TestGudPyIO(TestCase):
                 + "\n\n}"
             )
         with self.assertRaises(ParserException) as cm:
-            GudrunFile("test_data.txt")
+            GudrunFile("test_data.txt", format=Format.TXT)
         self.assertEqual((
             'INSTRUMENT, BEAM and NORMALISATION'
             ' were not parsed. It\'s possible the file'
@@ -976,7 +977,7 @@ class TestGudPyIO(TestCase):
             f.write("BEAM        {\n\n" + str(self.goodBeam) + "\n\n}\n\n")
 
         with self.assertRaises(ParserException) as cm:
-            GudrunFile("test_data.txt")
+            GudrunFile("test_data.txt", format=Format.TXT)
         self.assertEqual((
             'INSTRUMENT, BEAM and NORMALISATION'
             ' were not parsed. It\'s possible the file'
@@ -995,7 +996,7 @@ class TestGudPyIO(TestCase):
             )
 
         with self.assertRaises(ParserException) as cm:
-            GudrunFile("test_data.txt")
+            GudrunFile("test_data.txt", format=Format.TXT)
         self.assertEqual((
             'INSTRUMENT, BEAM and NORMALISATION'
             ' were not parsed. It\'s possible the file supplied'
@@ -1009,7 +1010,7 @@ class TestGudPyIO(TestCase):
             f.write("BEAM        {\n\n" + str(self.goodBeam) + "\n\n}")
 
         with self.assertRaises(ParserException) as cm:
-            GudrunFile("test_data.txt")
+            GudrunFile("test_data.txt", format=Format.TXT)
         self.assertEqual((
             'INSTRUMENT, BEAM and NORMALISATION'
             ' were not parsed. It\'s possible the file'
@@ -1026,7 +1027,7 @@ class TestGudPyIO(TestCase):
             )
 
         with self.assertRaises(ParserException) as cm:
-            GudrunFile("test_data.txt")
+            GudrunFile("test_data.txt", format=Format.TXT)
         self.assertEqual((
             'INSTRUMENT, BEAM and NORMALISATION'
             ' were not parsed. It\'s possible the file'
@@ -1060,7 +1061,7 @@ class TestGudPyIO(TestCase):
                 )
 
             with self.assertRaises(ParserException) as cm:
-                GudrunFile("test_data.txt")
+                GudrunFile("test_data.txt", format=Format.TXT)
                 self.assertEqual(
                     "Whilst parsing Instrument, an exception occured."
                     " The input file is most likely of an incorrect format, "
@@ -1095,7 +1096,7 @@ class TestGudPyIO(TestCase):
                     "INSTRUMENT        {\n\n" + str(badInstrument) + "\n\n}"
                 )
             with self.assertRaises(ParserException) as cm:
-                GudrunFile("test_data.txt")
+                GudrunFile("test_data.txt", format=Format.TXT)
                 self.assertEqual(
                     "Whilst parsing Instrument, an exception occured."
                     " The input file is most likely of an incorrect format, "
@@ -1131,7 +1132,7 @@ class TestGudPyIO(TestCase):
                 f.write("\n\nBEAM        {\n\n" + str(badBeam) + "\n\n}")
 
             with self.assertRaises(ParserException) as cm:
-                GudrunFile("test_data.txt")
+                GudrunFile("test_data.txt", format=Format.TXT)
                 self.assertEqual(
                     "Whilst parsing Beam, an exception occured."
                     " The input file is most likely of an incorrect format, "
@@ -1171,7 +1172,7 @@ class TestGudPyIO(TestCase):
                 f.write("\n\nBEAM        {\n\n" + str(badBeam) + "\n\n}")
 
             with self.assertRaises(ParserException) as cm:
-                GudrunFile("test_data.txt")
+                GudrunFile("test_data.txt", format=Format.TXT)
                 self.assertEqual(
                     "Whilst parsing Beam, an exception occured."
                     " The input file is most likely of an incorrect format, "
@@ -1217,7 +1218,7 @@ class TestGudPyIO(TestCase):
                 )
 
             with self.assertRaises(ParserException) as cm:
-                GudrunFile("test_data.txt")
+                GudrunFile("test_data.txt", format=Format.TXT)
                 self.assertEqual(
                     "Whilst parsing Beam, an exception occured."
                     " The input file is most likely of an incorrect format, "
@@ -1267,7 +1268,7 @@ class TestGudPyIO(TestCase):
                 )
 
             with self.assertRaises(ParserException) as cm:
-                GudrunFile("test_data.txt")
+                GudrunFile("test_data.txt", format=Format.TXT)
                 self.assertEqual(
                     "Whilst parsing Normalisation, an exception occured."
                     " The input file is most likely of an incorrect format, "
@@ -1292,7 +1293,7 @@ class TestGudPyIO(TestCase):
             )
             f.write("\n\n{}\n\nEND".format(str(badSampleBackground)))
         with self.assertRaises(ParserException) as cm:
-            GudrunFile("test_data.txt")
+            GudrunFile("test_data.txt", format=Format.TXT)
             self.assertEqual(
                 "Whilst parsing Sample Background, an exception occured."
                 " The input file is most likely of an incorrect format, "
@@ -1348,7 +1349,7 @@ class TestGudPyIO(TestCase):
                 f.write("\n\n{}\n\nEND".format(str(badSampleBackground)))
 
             with self.assertRaises(ParserException) as cm:
-                GudrunFile("test_data.txt")
+                GudrunFile("test_data.txt", format=Format.TXT)
                 self.assertEqual(
                     "Whilst parsing Sample, an exception occured."
                     " The input file is most likely of an incorrect format, "
@@ -1407,7 +1408,7 @@ class TestGudPyIO(TestCase):
                 f.write("\n\n{}\n\nEND".format(str(badSampleBackground)))
 
             with self.assertRaises(ParserException) as cm:
-                GudrunFile("test_data.txt")
+                GudrunFile("test_data.txt", format=Format.TXT)
                 self.assertEqual(
                     "Whilst parsing Sample, an exception occured."
                     " The input file is most likely of an incorrect format, "
@@ -1468,7 +1469,7 @@ class TestGudPyIO(TestCase):
                 )
                 f.write("\n\n{}\n\nEND".format(str(badSampleBackground)))
             with self.assertRaises(ParserException) as cm:
-                GudrunFile("test_data.txt")
+                GudrunFile("test_data.txt", format=Format.TXT)
                 self.assertEqual(
                     "Whilst parsing Container, an exception occured."
                     " The input file is most likely of an incorrect format, "

--- a/gudpy/test/test_gudpy_io.py
+++ b/gudpy/test/test_gudpy_io.py
@@ -901,9 +901,9 @@ class TestGudPyIO(TestCase):
         g1 = GudrunFile(
             os.path.join(
                 self.g.instrument.GudrunInputFileDir,
-                format=Format.TXT.outpath
+                self.g.outpath
             ),
-            Format.TXT
+            format=Format.TXT
         )
         g1.instrument.GudrunInputFileDir = self.g.instrument.GudrunInputFileDir
         self.assertEqual(
@@ -1532,15 +1532,16 @@ class TestGudPyIO(TestCase):
                 )
                 f.write("\n\n{}\n\nEND".format(str(badSampleBackground)))
             with self.assertRaises(ParserException) as cm:
-                GudrunFile("test_data.txt")
+                GudrunFile("test_data.txt", format=Format.TXT)
                 self.assertEqual(
                     "Whilst parsing Container, an exception occured."
                     " The input file is most likely of an incorrect format, "
                     "and some attributes were missing.",
                     str(cm.exception)
                 )
-format=Format.TXT
+
     def testZeroExitGudrun(self):
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
+        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt",
+                       format=Format.TXT)
         result = g.dcs()
         self.assertEqual(result.stderr, "")

--- a/gudpy/test/test_gudpy_io.py
+++ b/gudpy/test/test_gudpy_io.py
@@ -20,7 +20,7 @@ from core.sample import Sample
 from core.enums import (
     CrossSectionSource, FTModes, Instruments, Scales, UnitsOfDensity,
     MergeWeights, NormalisationType, OutputUnits,
-    Geometry
+    Geometry, Format
 )
 
 
@@ -115,7 +115,7 @@ class TestGudPyIO(TestCase):
             "sampleDependantBackgroundFactor": 0.0,
             "shieldingAttenuationCoefficient": 0.0,
             "yamlignore": {
-               "yamlignore"
+                "yamlignore"
             }
         }
 
@@ -527,9 +527,9 @@ class TestGudPyIO(TestCase):
         }
 
         self.expectedSampleC["composition"].elements = [
-                    Element("H", 0.0, 1.0),
-                    Element("O", 0.0, 1.0),
-                    Element("H", 2.0, 1.0),
+            Element("H", 0.0, 1.0),
+            Element("O", 0.0, 1.0),
+            Element("H", 2.0, 1.0),
         ]
 
         self.expectedSampleD = {
@@ -631,7 +631,7 @@ class TestGudPyIO(TestCase):
             0
         ].__dict__ = self.expectedContainerA
 
-        self.g = GudrunFile(dirpath)
+        self.g = GudrunFile(dirpath, Format.TXT)
 
         self.dicts = [
             self.expectedInstrument,
@@ -651,7 +651,7 @@ class TestGudPyIO(TestCase):
         self.keepsakes = os.listdir()
 
         copyfile(self.g.path, "test/TestData/NIMROD-water/good_water.txt")
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt")
+        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
 
         g.write_out(overwrite=True)
         return super().setUp()
@@ -900,7 +900,8 @@ class TestGudPyIO(TestCase):
             os.path.join(
                 self.g.instrument.GudrunInputFileDir,
                 self.g.outpath
-            )
+            ),
+            Format.TXT
         )
         g1.instrument.GudrunInputFileDir = self.g.instrument.GudrunInputFileDir
         self.assertEqual(
@@ -914,10 +915,10 @@ class TestGudPyIO(TestCase):
         with self.assertRaises(ParserException) as cm:
             GudrunFile("test_data.txt")
         self.assertEqual((
-                    'INSTRUMENT, BEAM and NORMALISATION'
-                    ' were not parsed. It\'s possible the file'
-                    ' supplied is of an incorrect format!'
-                ),
+            'INSTRUMENT, BEAM and NORMALISATION'
+            ' were not parsed. It\'s possible the file'
+            ' supplied is of an incorrect format!'
+        ),
             str(cm.exception),
         )
 
@@ -934,10 +935,10 @@ class TestGudPyIO(TestCase):
         with self.assertRaises(ParserException) as cm:
             GudrunFile("test_data.txt")
         self.assertEqual((
-                    'INSTRUMENT, BEAM and NORMALISATION'
-                    ' were not parsed. It\'s possible the file'
-                    ' supplied is of an incorrect format!'
-                ),
+            'INSTRUMENT, BEAM and NORMALISATION'
+            ' were not parsed. It\'s possible the file'
+            ' supplied is of an incorrect format!'
+        ),
             str(cm.exception),
         )
 
@@ -956,10 +957,10 @@ class TestGudPyIO(TestCase):
         with self.assertRaises(ParserException) as cm:
             GudrunFile("test_data.txt")
         self.assertEqual((
-                    'INSTRUMENT, BEAM and NORMALISATION'
-                    ' were not parsed. It\'s possible the file'
-                    ' supplied is of an incorrect format!'
-                ),
+            'INSTRUMENT, BEAM and NORMALISATION'
+            ' were not parsed. It\'s possible the file'
+            ' supplied is of an incorrect format!'
+        ),
             str(cm.exception),
         )
 
@@ -975,10 +976,10 @@ class TestGudPyIO(TestCase):
         with self.assertRaises(ParserException) as cm:
             GudrunFile("test_data.txt")
         self.assertEqual((
-                    'INSTRUMENT, BEAM and NORMALISATION'
-                    ' were not parsed. It\'s possible the file'
-                    ' supplied is of an incorrect format!'
-                ),
+            'INSTRUMENT, BEAM and NORMALISATION'
+            ' were not parsed. It\'s possible the file'
+            ' supplied is of an incorrect format!'
+        ),
             str(cm.exception),
         )
 
@@ -1008,10 +1009,10 @@ class TestGudPyIO(TestCase):
         with self.assertRaises(ParserException) as cm:
             GudrunFile("test_data.txt")
         self.assertEqual((
-                    'INSTRUMENT, BEAM and NORMALISATION'
-                    ' were not parsed. It\'s possible the file'
-                    ' supplied is of an incorrect format!'
-                ),
+            'INSTRUMENT, BEAM and NORMALISATION'
+            ' were not parsed. It\'s possible the file'
+            ' supplied is of an incorrect format!'
+        ),
             str(cm.exception),
         )
 
@@ -1025,10 +1026,10 @@ class TestGudPyIO(TestCase):
         with self.assertRaises(ParserException) as cm:
             GudrunFile("test_data.txt")
         self.assertEqual((
-                    'INSTRUMENT, BEAM and NORMALISATION'
-                    ' were not parsed. It\'s possible the file'
-                    ' supplied is of an incorrect format!'
-                ),
+            'INSTRUMENT, BEAM and NORMALISATION'
+            ' were not parsed. It\'s possible the file'
+            ' supplied is of an incorrect format!'
+        ),
             str(cm.exception),
         )
 
@@ -1538,7 +1539,6 @@ class TestGudPyIO(TestCase):
                 )
 
     def testZeroExitGudrun(self):
-
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt")
+        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         result = g.dcs()
         self.assertEqual(result.stderr, "")

--- a/gudpy/test/test_gudpy_io.py
+++ b/gudpy/test/test_gudpy_io.py
@@ -631,7 +631,7 @@ class TestGudPyIO(TestCase):
             0
         ].__dict__ = self.expectedContainerA
 
-        self.g = GudrunFile(dirpath, Format.TXT)
+        self.g = GudrunFile(dirpath, format=Format.TXT)
 
         self.dicts = [
             self.expectedInstrument,
@@ -651,7 +651,9 @@ class TestGudPyIO(TestCase):
         self.keepsakes = os.listdir()
 
         copyfile(self.g.path, "test/TestData/NIMROD-water/good_water.txt")
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
+        g = GudrunFile(
+            "test/TestData/NIMROD-water/good_water.txt",
+            format=Format.TXT)
 
         g.write_out(overwrite=True)
         return super().setUp()
@@ -899,7 +901,7 @@ class TestGudPyIO(TestCase):
         g1 = GudrunFile(
             os.path.join(
                 self.g.instrument.GudrunInputFileDir,
-                self.g.outpath
+                format=Format.TXT.outpath
             ),
             Format.TXT
         )
@@ -1537,7 +1539,7 @@ class TestGudPyIO(TestCase):
                     "and some attributes were missing.",
                     str(cm.exception)
                 )
-
+format=Format.TXT
     def testZeroExitGudrun(self):
         g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
         result = g.dcs()

--- a/gudpy/test/test_gudpy_workflows.py
+++ b/gudpy/test/test_gudpy_workflows.py
@@ -30,7 +30,7 @@ class TestGudPyWorkflows(TestCase):
         copyfile(self.g.path, "test/TestData/NIMROD-water/good_water.txt")
         g = GudrunFile(
             os.path.abspath("test/TestData/NIMROD-water/good_water.txt"),
-            Format.TXT
+            format=Format.TXT
         )
 
         from pathlib import Path

--- a/gudpy/test/test_gudpy_workflows.py
+++ b/gudpy/test/test_gudpy_workflows.py
@@ -15,6 +15,7 @@ from core.gud_file import GudFile
 from core.wavelength_subtraction_iterator import (
     WavelengthSubtractionIterator
 )
+from core.enums import Format
 
 
 class TestGudPyWorkflows(TestCase):
@@ -28,7 +29,8 @@ class TestGudPyWorkflows(TestCase):
 
         copyfile(self.g.path, "test/TestData/NIMROD-water/good_water.txt")
         g = GudrunFile(
-            os.path.abspath("test/TestData/NIMROD-water/good_water.txt")
+            os.path.abspath("test/TestData/NIMROD-water/good_water.txt"),
+            Format.TXT
         )
 
         from pathlib import Path
@@ -106,10 +108,10 @@ class TestGudPyWorkflows(TestCase):
                     self.g.instrument.GudrunInputFileDir, mintFilename
                 ),
                 "r", encoding="utf-8"
-                ).readlines()[10:]
+            ).readlines()[10:]
             expectedData = open(
                 actualMintFile, "r", encoding="utf-8"
-                ).readlines()[10:]
+            ).readlines()[10:]
             close = 0
             total = 0
             for a, b in zip(actualData, expectedData):
@@ -122,9 +124,9 @@ class TestGudPyWorkflows(TestCase):
                         float(x.strip()),
                         float(y.strip()),
                         rel_tol=0.01
-                            ):
+                    ):
                         close += 1
-            self.assertTrue((close/total) >= 0.95)
+            self.assertTrue((close / total) >= 0.95)
 
     def testGudPyIterateByTweakFactor(self):
 
@@ -372,7 +374,7 @@ class TestGudPyWorkflows(TestCase):
                     x
                     for x in self.g.sampleBackgrounds[0].samples
                     if x.runThisSample
-                    ]:
+            ]:
                 mintFilename = (
                     sample.dataFiles[0].replace(
                         self.g.instrument.dataFileType, "mint01"
@@ -385,14 +387,14 @@ class TestGudPyWorkflows(TestCase):
                 )
 
                 actualData = open(
-                   os.path.join(
-                       self.g.instrument.GudrunInputFileDir,
-                       mintFilename
-                   ), "r", encoding="utf-8"
+                    os.path.join(
+                        self.g.instrument.GudrunInputFileDir,
+                        mintFilename
+                    ), "r", encoding="utf-8"
                 ).readlines()[10:]
                 expectedData = open(
                     actualMintFile, "r", encoding="utf-8"
-                    ).readlines()[10:]
+                ).readlines()[10:]
                 close = 0
                 total = 0
                 for a, b in zip(actualData, expectedData):
@@ -405,9 +407,9 @@ class TestGudPyWorkflows(TestCase):
                             float(x.strip()),
                             float(y.strip()),
                             rel_tol=0.02
-                                ):
+                        ):
                             close += 1
-                self.assertTrue((close/total) >= 0.95)
+                self.assertTrue((close / total) >= 0.95)
 
                 msubFilename = (
                     sample.dataFiles[0].replace(
@@ -420,14 +422,14 @@ class TestGudPyWorkflows(TestCase):
                 )
 
                 actualData = open(
-                   os.path.join(
-                       self.g.instrument.GudrunInputFileDir,
-                       msubFilename
-                   ), "r", encoding="utf-8"
+                    os.path.join(
+                        self.g.instrument.GudrunInputFileDir,
+                        msubFilename
+                    ), "r", encoding="utf-8"
                 ).readlines()[10:]
                 expectedData = open(
                     actualMsubFilename, "r", encoding="utf-8"
-                    ).readlines()[10:]
+                ).readlines()[10:]
                 close = 0
                 total = 0
                 for a, b in zip(actualData, expectedData):
@@ -441,6 +443,6 @@ class TestGudPyWorkflows(TestCase):
                             float(x.strip()),
                             float(y.strip()),
                             rel_tol=0.02
-                                ):
+                        ):
                             close += 1
-                self.assertTrue((close/total) >= 0.95)
+                self.assertTrue((close / total) >= 0.95)

--- a/gudpy/test/test_gudpy_workflows.py
+++ b/gudpy/test/test_gudpy_workflows.py
@@ -23,7 +23,7 @@ class TestGudPyWorkflows(TestCase):
 
         path = os.path.abspath("test/TestData/NIMROD-water/water.txt")
 
-        self.g = GudrunFile(os.path.abspath(path))
+        self.g = GudrunFile(os.path.abspath(path), format=Format.TXT)
 
         self.keepsakes = os.listdir()
 

--- a/gudpy/test/test_gudpy_yaml.py
+++ b/gudpy/test/test_gudpy_yaml.py
@@ -9,9 +9,10 @@ class TestYAML(TestCase):
 
         gf1 = GudrunFile(
             "test/TestData/NIMROD-water/water.txt",
-            format=Format.TXT)format=Format.TXT
+            format=Format.TXT)
         gf1.write_yaml("test/TestData/NIMROD-water/water.yaml")
-        gf2 = GudrunFile("test/TestData/NIMROD-water/water.yaml", Format.TXT)
+        gf2 = GudrunFile("test/TestData/NIMROD-water/water.yaml",
+                         format=Format.TXT)
 
         self.assertDictEqual(gf1.instrument.__dict__, gf2.instrument.__dict__)
         self.assertDictEqual(gf2.beam.__dict__, gf2.beam.__dict__)

--- a/gudpy/test/test_gudpy_yaml.py
+++ b/gudpy/test/test_gudpy_yaml.py
@@ -1,14 +1,15 @@
 from unittest import TestCase
 
 from core.gudrun_file import GudrunFile
+from core.enums import Format
 
 
 class TestYAML(TestCase):
     def testYAML(self):
 
-        gf1 = GudrunFile("test/TestData/NIMROD-water/water.txt")
+        gf1 = GudrunFile("test/TestData/NIMROD-water/water.txt", Format.TXT)
         gf1.write_yaml("test/TestData/NIMROD-water/water.yaml")
-        gf2 = GudrunFile("test/TestData/NIMROD-water/water.yaml")
+        gf2 = GudrunFile("test/TestData/NIMROD-water/water.yaml", Format.TXT)
 
         self.assertDictEqual(gf1.instrument.__dict__, gf2.instrument.__dict__)
         self.assertDictEqual(gf2.beam.__dict__, gf2.beam.__dict__)

--- a/gudpy/test/test_gudpy_yaml.py
+++ b/gudpy/test/test_gudpy_yaml.py
@@ -7,7 +7,9 @@ from core.enums import Format
 class TestYAML(TestCase):
     def testYAML(self):
 
-        gf1 = GudrunFile("test/TestData/NIMROD-water/water.txt", Format.TXT)
+        gf1 = GudrunFile(
+            "test/TestData/NIMROD-water/water.txt",
+            format=Format.TXT)format=Format.TXT
         gf1.write_yaml("test/TestData/NIMROD-water/water.yaml")
         gf2 = GudrunFile("test/TestData/NIMROD-water/water.yaml", Format.TXT)
 

--- a/gudpy/test/test_gudpy_yaml.py
+++ b/gudpy/test/test_gudpy_yaml.py
@@ -11,8 +11,7 @@ class TestYAML(TestCase):
             "test/TestData/NIMROD-water/water.txt",
             format=Format.TXT)
         gf1.write_yaml("test/TestData/NIMROD-water/water.yaml")
-        gf2 = GudrunFile("test/TestData/NIMROD-water/water.yaml",
-                         format=Format.TXT)
+        gf2 = GudrunFile("test/TestData/NIMROD-water/water.yaml")
 
         self.assertDictEqual(gf1.instrument.__dict__, gf2.instrument.__dict__)
         self.assertDictEqual(gf2.beam.__dict__, gf2.beam.__dict__)

--- a/gudpy/test/test_purge_file.py
+++ b/gudpy/test/test_purge_file.py
@@ -5,6 +5,7 @@ from shutil import copyfile
 
 from core.gudrun_file import GudrunFile
 from core.purge_file import PurgeFile
+from core.enums import Format
 
 
 class TestPurgeFile(TestCase):
@@ -21,12 +22,12 @@ class TestPurgeFile(TestCase):
                 + "/"
                 + path
             )
-        self.g = GudrunFile(dirpath)
+        self.g = GudrunFile(dirpath, Format.TXT)
 
         self.keepsakes = os.listdir()
 
         copyfile(self.g.path, "test/TestData/NIMROD-water/good_water.txt")
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt")
+        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
 
         g.write_out(overwrite=True)
         self.g = g

--- a/gudpy/test/test_purge_file.py
+++ b/gudpy/test/test_purge_file.py
@@ -22,12 +22,14 @@ class TestPurgeFile(TestCase):
                 + "/"
                 + path
             )
-        self.g = GudrunFile(dirpath, Format.TXT)
+        self.g = GudrunFile(dirpath, format=Format.TXT)
 
         self.keepsakes = os.listdir()
 
         copyfile(self.g.path, "test/TestData/NIMROD-water/good_water.txt")
-        g = GudrunFile("test/TestData/NIMROD-water/good_water.txt", Format.TXT)
+        g = GudrunFile(
+            "test/TestData/NIMROD-water/good_water.txt",
+            format=Format.TXT)
 
         g.write_out(overwrite=True)
         self.g = g


### PR DESCRIPTION
More detailed error reporting/handling when inputting a YAML file.

Previously an invalid YAML file would be assumed to be a .txt file and GudPy would attempt to parse it as a Gudrun input file which led to unspecific error reporting. Now YAML & TXT files are dealt with separately.

Fixed the issue of outputted YAML files not being able to be read back in. This was due to an incorrect encoding being used which caused the Angstrom symbol to be misread.

Closes #450 