### PR TITLE
Small change to how window is named

### DIFF
--- a/gudpy/core/gudrun_file.py
+++ b/gudpy/core/gudrun_file.py
@@ -141,6 +141,7 @@ class GudrunFile:
         """
 
         self.path = path
+        self.filename = os.path.basename(path)
         self.yaml = YAML()
 
         # Construct the outpath.

--- a/gudpy/gui/widgets/core/main_window.py
+++ b/gudpy/gui/widgets/core/main_window.py
@@ -640,7 +640,8 @@ class GudPyMainWindow(QMainWindow):
                 path = self.tryLoadAutosaved(filename)
                 self.gudrunFile = GudrunFile(path=path)
                 self.updateWidgets()
-                self.mainWidget.setWindowTitle(self.gudrunFile.path + " [*]")
+                self.mainWidget.setWindowTitle(
+                    f"GudPy - {self.gudrunFile.filename}")
             except ParserException as e:
                 QMessageBox.critical(self.mainWidget, "GudPy Error", str(e))
 


### PR DESCRIPTION
The previous title would show the whole path:
![image](https://github.com/disorderedmaterials/GudPy/assets/101950441/12846bf1-c9fc-49be-a6c9-66e79b3cf9f9)

Now shows 'GudPy' and just the input filename (similar to how it is done in Dissolve):
![image](https://github.com/disorderedmaterials/GudPy/assets/101950441/888e795d-26a6-46b6-ae42-60a04fe868a8)
