### PR TITLE
470 Remove 'Duplicate File' Button & Select Multiple Files

### DIFF
--- a/gudpy/gui/widgets/slots/normalisation_slots.py
+++ b/gudpy/gui/widgets/slots/normalisation_slots.py
@@ -138,12 +138,6 @@ class NormalisationSlots():
             )
         )
 
-        self.widget.duplicateDataFileButton.clicked.connect(
-            lambda: self.duplicateDataFile(
-                self.widget.dataFilesList
-            )
-        )
-
         self.widget.addBackgroundDataFileButton.clicked.connect(
             lambda: self.addDataFiles(
                 self.widget.backgroundDataFilesList,
@@ -155,12 +149,6 @@ class NormalisationSlots():
 
         self.widget.removeBackgroundDataFileButton.clicked.connect(
             lambda: self.removeDataFile(
-                self.widget.backgroundDataFilesList
-            )
-        )
-
-        self.widget.duplicateBackgroundDataFileButton.clicked.connect(
-            lambda: self.duplicateDataFile(
                 self.widget.backgroundDataFilesList
             )
         )

--- a/gudpy/gui/widgets/slots/normalisation_slots.py
+++ b/gudpy/gui/widgets/slots/normalisation_slots.py
@@ -1,5 +1,6 @@
 import os
 from PySide6.QtWidgets import QFileDialog
+from PySide6.QtWidgets import QAbstractItemView
 
 from core.enums import (
     Geometry, CrossSectionSource, UnitsOfDensity, Instruments
@@ -23,6 +24,13 @@ class NormalisationSlots():
         )
         self.widget.backgroundDataFilesList.makeModel(
             self.normalisation.dataFilesBg.dataFiles
+        )
+
+        self.widget.dataFilesList.setSelectionMode(
+            QAbstractItemView.ExtendedSelection)
+
+        self.widget.backgroundDataFilesList.setSelectionMode(
+            QAbstractItemView.ExtendedSelection
         )
 
         self.widget.dataFilesList.model().dataChanged.connect(
@@ -633,10 +641,6 @@ class NormalisationSlots():
         Called when an itemChanged signal is emitted,
         from the dataFilesList.
         Alters the normalisation's data files as such.
-        Parameters
-        ----------
-        item : QListWidgetItem
-            The item altered.
         """
         if not self.widgetsRefreshing:
             self.parent.setModified()
@@ -651,10 +655,6 @@ class NormalisationSlots():
         Called when an itemChanged signal is emitted,
         from the dataFilesList.
         Alters the normalisation's data files as such.
-        Parameters
-        ----------
-        item : QListWidgetItem
-            The item altered.
         """
         if not self.widgetsRefreshing:
             self.parent.setModified()

--- a/gudpy/gui/widgets/tables/data_file_list.py
+++ b/gudpy/gui/widgets/tables/data_file_list.py
@@ -40,4 +40,5 @@ class DataFilesList(QListView):
         Removes rows from the model.
         """
         if self.currentIndex().isValid():
-            self.model().removeRow(self.currentIndex().row())
+            for index in self.selectedIndexes():
+                self.model().removeRow(index.row())

--- a/gudpy/gui/widgets/tables/data_file_list.py
+++ b/gudpy/gui/widgets/tables/data_file_list.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import QModelIndex, QStringListModel
+from PySide6.QtCore import QModelIndex, QStringListModel, QPersistentModelIndex
 from PySide6.QtWidgets import QListView
 
 
@@ -40,5 +40,9 @@ class DataFilesList(QListView):
         Removes rows from the model.
         """
         if self.currentIndex().isValid():
-            for index in self.selectedIndexes():
+            indexes = []
+            for index_ref in self.selectedIndexes():
+                index = QPersistentModelIndex(index_ref)
+                indexes.append(index)
+            for index in indexes:
                 self.model().removeRow(index.row())

--- a/gudpy/gui/widgets/ui_files/mainWindow.ui
+++ b/gudpy/gui/widgets/ui_files/mainWindow.ui
@@ -3368,17 +3368,6 @@
                       </widget>
                      </item>
                      <item>
-                      <widget class="QToolButton" name="duplicateDataFileButton">
-                       <property name="text">
-                        <string>...</string>
-                       </property>
-                       <property name="icon">
-                        <iconset resource="../resources/resources.qrc">
-                         <normaloff>:/icons/duplicate.png</normaloff>:/icons/duplicate.png</iconset>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
                       <spacer name="verticalSpacer_7">
                        <property name="orientation">
                         <enum>Qt::Vertical</enum>
@@ -3516,17 +3505,6 @@
                        <property name="icon">
                         <iconset resource="../resources/resources.qrc">
                          <normaloff>:/icons/minus.png</normaloff>:/icons/minus.png</iconset>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QToolButton" name="duplicateBackgroundDataFileButton">
-                       <property name="text">
-                        <string>...</string>
-                       </property>
-                       <property name="icon">
-                        <iconset resource="../resources/resources.qrc">
-                         <normaloff>:/icons/duplicate.png</normaloff>:/icons/duplicate.png</iconset>
                        </property>
                       </widget>
                      </item>


### PR DESCRIPTION
This PR removes the button that duplicates data files, as well as allows for multiple files to be selected and removed.

Closes #470 